### PR TITLE
support create_configuration with no args.

### DIFF
--- a/include/tateyama/api/configuration.h
+++ b/include/tateyama/api/configuration.h
@@ -169,7 +169,7 @@ private:
     }
 };
 
-inline std::shared_ptr<whole> create_configuration(std::string_view file_name) {
+inline std::shared_ptr<whole> create_configuration(std::string_view file_name = "") {
     try {
         return std::make_shared<whole>(file_name);
     } catch (boost::property_tree::ptree_error &e) {

--- a/test/tateyama/api/configuration_test.cpp
+++ b/test/tateyama/api/configuration_test.cpp
@@ -29,7 +29,7 @@ public:
 using namespace std::string_view_literals;
 
 TEST_F(configuration_test, add_new_property) {
-    auto cfg = api::configuration::create_configuration("");
+    auto cfg = api::configuration::create_configuration();
     auto section = cfg->get_section("data_store"); // any section name is fine for testing
     ASSERT_TRUE(section);
     ASSERT_TRUE(section->set("test", "value"));
@@ -48,7 +48,7 @@ TEST_F(configuration_test, add_new_property) {
 }
 
 TEST_F(configuration_test, add_new_property_bool) {
-    auto cfg = api::configuration::create_configuration("");
+    auto cfg = api::configuration::create_configuration();
     auto section = cfg->get_section("data_store"); // any section name is fine for testing
     ASSERT_TRUE(section);
     ASSERT_TRUE(section->set("test", "true"));
@@ -62,7 +62,7 @@ TEST_F(configuration_test, add_new_property_bool) {
 }
 
 TEST_F(configuration_test, add_same_name_property_to_different_section) {
-    auto cfg = api::configuration::create_configuration("");
+    auto cfg = api::configuration::create_configuration();
     auto section0 = cfg->get_section("data_store"); // any section name is fine for testing
     auto section1 = cfg->get_section("sql"); // any section name is fine for testing
     ASSERT_TRUE(section0);


### PR DESCRIPTION
create_configuration関数にデフォルト引数を設定する変更です。
テスト等でデフォルトのコンフィグを使用する時にcreate_configuration("")と存在しないファイルパスを指定するのが美しくないので追加したいと思っています。問題なければマージお願いします。