### PR TITLE
Replaced call of deprecated MessageLite::ByteSize()

### DIFF
--- a/src/tateyama/utils/protobuf_utils.cpp
+++ b/src/tateyama/utils/protobuf_utils.cpp
@@ -79,7 +79,7 @@ bool SerializeDelimitedToCodedStream(
     google::protobuf::io::CodedOutputStream* output
 ) {
     // Write the size.
-    size_t size = message.ByteSize();
+    size_t size = message.ByteSizeLong();
     if (size > INT_MAX) return false;
 
     output->WriteVarint32(size);


### PR DESCRIPTION
Protobuf が新しい環境ではビルドが通らなくなる問題がありました。その修正対応です。
コンパイルが通る Ubuntu 20.04 環境(protobuf 3.6.1.3) でも
「PROTOBUF_RUNTIME_DEPRECATED」だったことから、`ByteSize()` の使用は推奨されていないようでした。

原因:

```c++
  // Legacy ByteSize() API.
  PROTOBUF_RUNTIME_DEPRECATED("Please use ByteSizeLong() instead")
```

* 以前は DEPRECATED はコンパイル時になにもされていなかったようだが(??)、 protobuf v3.11.0 からはコンパイル時警告が出るようになったようだ
    * https://github.com/protocolbuffers/protobuf/releases/tag/v3.11.0
    * https://github.com/protocolbuffers/protobuf/pull/6612
* コンパイル時警告はコンパイルエラーとなるオプションをつけてビルドされている
