### PR TITLE
add `-DENABLE_JEMALLOC` cmake option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static" ON)
 option(ENABLE_CACHE_ALIGN "enable optional cache align requirement" OFF)
 option(MC_QUEUE "use moody-camel queue" OFF)
 option(TRACY_ENABLE "enable tracy profiler" OFF)
+option(ENABLE_JEMALLOC "use jemalloc instead of default malloc" OFF)
 
 if(NOT DEFINED SHARKSFIN_IMPLEMENTATION)
     set(
@@ -63,6 +64,11 @@ find_package(TBB REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(msgpack REQUIRED)
 find_package(mpdecpp REQUIRED)
+
+if (ENABLE_JEMALLOC)
+    find_package(jemalloc REQUIRED)
+endif (ENABLE_JEMALLOC)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(CompileOptions)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ available options:
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `memory`)
 * `-DPERFORMANCE_TOOLS=ON` - enable performance tooling to measure engine performance
 * `-DMC_QUEUE=ON` - use moody camel queue instead of tbb queue to store tasks in tateyama task scheduler.
+* `-DENABLE_JEMALLOC` - use jemalloc instead of default `malloc`
 * for debugging only
   * `-DENABLE_SANITIZER=OFF` - disable sanitizers (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DENABLE_UB_SANITIZER=ON` - enable undefined behavior sanitizer (requires `-DENABLE_SANITIZER=ON`)

--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -1,0 +1,34 @@
+# Copyright 2018-2023 Tsurugi project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(TARGET jemalloc::jemalloc)
+    return()
+endif()
+
+find_library(jemalloc_LIBRARY_FILE NAMES jemalloc)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(jemalloc DEFAULT_MSG
+    jemalloc_LIBRARY_FILE)
+
+if(jemalloc_LIBRARY_FILE)
+    set(jemalloc_FOUND ON)
+    add_library(jemalloc::jemalloc SHARED IMPORTED)
+    set_target_properties(jemalloc::jemalloc PROPERTIES
+        IMPORTED_LOCATION "${jemalloc_LIBRARY_FILE}")
+else()
+    set(jemalloc_FOUND OFF)
+endif()
+
+unset(jemalloc_LIBRARY_FILE CACHE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,10 @@ if(MC_QUEUE)
     target_compile_definitions(${ENGINE} PUBLIC MC_QUEUE)
 endif()
 
+if (ENABLE_JEMALLOC)
+    target_link_libraries(${ENGINE} PRIVATE jemalloc::jemalloc)
+endif (ENABLE_JEMALLOC)
+
 # Boost.Thread doesn't seem to allow multiple versions to coexist.
 # This version definition should be shared with caller at least.
 target_compile_definitions(${ENGINE} PUBLIC BOOST_THREAD_VERSION=4)


### PR DESCRIPTION
This PR introduces a new cmake build option `-DENABLE_JEMALLOC=ON`.