### PR TITLE
fix default timeout to 180[sec]

### DIFF
--- a/test/tateyama/endpoint/ipc/server_client_base.h
+++ b/test/tateyama/endpoint/ipc/server_client_base.h
@@ -44,7 +44,7 @@ protected:
     int nthread_;
     int nworker_;
 
-    int maxsec_ = 60;
+    int maxsec_ = 180;
 
 private:
     // for server process


### PR DESCRIPTION
IPCテストの、デフォルトタイムアウト時間を１８０秒に伸ばしました