### PR TITLE
Stop using MD5 functions of openssl (for FTBFS with OpenSSL 3.0)

### DIFF
--- a/src/tateyama/status/resource/bridge.cpp
+++ b/src/tateyama/status/resource/bridge.cpp
@@ -98,7 +98,7 @@ void bridge::add_shm_entry(std::size_t session_id, std::size_t index) {
 }
 
 void bridge::set_digest(const std::string& path_string) {
-    std::size_t hash = std::hash<std::string>{}(path_string);
+    auto hash = std::hash<std::string>{}(path_string);
     std::ostringstream sstream;
     sstream << std::hex << std::setfill('0')
             << std::setw(sizeof(hash) * 2) << hash;


### PR DESCRIPTION
Ubuntu 22.04 LTS, Debian 12 で OpenSSL が 3.0 になり、 MD5 関連の関数が非推奨とされコンパイル警告が出るようになり、(さらに tsurugi ビルド時にコンパイル警告をすべてエラー扱いしてビルド失敗としているため) ビルドできなくなったことへの対応です。

Issue: project-tsurugi/tsurugi-issues#272

コンフィグレーションファイルのフルパスの文字列から、ハッシュでテンポラリファイル名を作成するのに使用していますが、そこまで良質なハッシュ関数でなくてもよいため、C++ の `std::hash` で代用するように変更しました。
(Issue のほうにコメントしましたが、現在のライブラリ実装では簡単にはハッシュ値衝突は起きないようです。)
tateyama と tateyama-bootstrap にほぼ同じルーチンがあるため、両方を変更します。

MD5 は 128bit のハッシュ値だったものを 64bit のハッシュ値で代用したため、ファイル名が短くなるという目に見える影響が出ていますが、サーバ内部動作は文字列長依存のコードはないため影響はないようです。
