### PR TITLE
change to not send core error from stream_endpoint to tsubakuro when …

### DIFF
--- a/src/tateyama/endpoint/stream/stream_response.h
+++ b/src/tateyama/endpoint/stream/stream_response.h
@@ -58,8 +58,8 @@ private:
 class stream_data_channel : public tateyama::api::server::data_channel {
 public:
     stream_data_channel() = delete;
-    explicit stream_data_channel(stream_socket& session_socket, unsigned int slot, stream_response& response)
-        : session_socket_(session_socket), slot_(slot), response_(response) {}
+    explicit stream_data_channel(stream_socket& session_socket, unsigned int slot)
+        : session_socket_(session_socket), slot_(slot) {}
     tateyama::status acquire(std::shared_ptr<tateyama::api::server::writer>& wrt) override;
     tateyama::status release(tateyama::api::server::writer& wrt) override;
     [[nodiscard]] unsigned int get_slot() const { return slot_; }
@@ -69,7 +69,6 @@ private:
     std::set<std::shared_ptr<stream_writer>, tateyama::endpoint::common::pointer_comp<stream_writer>> data_writers_{};
     std::mutex mutex_{};
     unsigned int slot_;
-    stream_response& response_;
     std::atomic_char writer_id_{};
 };
 


### PR DESCRIPTION
…error occurs in stream_response::acquire_channel() or stream_data_channel::acquire() and revise related message output