### PR TITLE
add response::error() to report tateyama layer errors

### DIFF
--- a/include/tateyama/api/server/response.h
+++ b/include/tateyama/api/server/response.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <tateyama/proto/diagnostics.pb.h>
+
 #include "data_channel.h"
 #include "response_code.h"
 
@@ -58,6 +60,15 @@ public:
      * @attention this function is not thread-safe and should be called from single thread at a time.
      */
     virtual void code(response_code code) = 0;
+
+    /**
+     * @brief report error with diagnostics information
+     * @param record the diagnostic record to report
+     * @details report an error with diagnostics information for client. When this function is called, no more
+     * body_head() or body() is expected to be called.
+     * @attention this function is not thread-safe and should be called from single thread at a time.
+     */
+    virtual void error(proto::diagnostics::Record const& record) = 0;
 
     /**
      * @brief setter of the response body head

--- a/src/tateyama/endpoint/ipc/ipc_response.cpp
+++ b/src/tateyama/endpoint/ipc/ipc_response.cpp
@@ -58,6 +58,10 @@ tateyama::status ipc_response::body_head(std::string_view body_head) {
     return tateyama::status::ok;
 }
 
+void ipc_response::error(proto::diagnostics::Record const&) {
+    //TODO implement
+}
+
 void ipc_response::server_diagnostics(std::string_view diagnostic_record) {
     VLOG_LP(log_trace) << static_cast<const void*>(server_wire_.get());  //NOLINT
 

--- a/src/tateyama/endpoint/ipc/ipc_response.cpp
+++ b/src/tateyama/endpoint/ipc/ipc_response.cpp
@@ -42,10 +42,9 @@ tateyama::status ipc_response::body(std::string_view body) {
         auto s = ss.str();
         server_wire_->get_response_wire().write(s.data(), response_header(index_, s.length(), RESPONSE_BODY));
         return tateyama::status::ok;
-    } else {
-        LOG_LP(ERROR) << "response is already completed";
-        return status::unknown;        
     }
+    LOG_LP(ERROR) << "response is already completed";
+    return status::unknown;        
 }
 
 tateyama::status ipc_response::body_head(std::string_view body_head) {

--- a/src/tateyama/endpoint/ipc/ipc_response.cpp
+++ b/src/tateyama/endpoint/ipc/ipc_response.cpp
@@ -58,13 +58,19 @@ tateyama::status ipc_response::body_head(std::string_view body_head) {
     return tateyama::status::ok;
 }
 
-void ipc_response::error(proto::diagnostics::Record const&) {
-    //TODO implement
+void ipc_response::error(proto::diagnostics::Record const& record) {
+    VLOG_LP(log_trace) << static_cast<const void*>(server_wire_.get());  //NOLINT
+
+    std::string s{};
+    if(record.SerializeToString(&s)) {
+        server_diagnostics(s);
+    } else {
+        LOG_LP(ERROR) << "error formatting diagnostics message";
+        server_diagnostics("");
+    }
 }
 
 void ipc_response::server_diagnostics(std::string_view diagnostic_record) {
-    VLOG_LP(log_trace) << static_cast<const void*>(server_wire_.get());  //NOLINT
-
     std::stringstream ss{};
     endpoint::common::header_content arg{};
     arg.session_id_ = session_id_;

--- a/src/tateyama/endpoint/ipc/ipc_response.h
+++ b/src/tateyama/endpoint/ipc/ipc_response.h
@@ -94,6 +94,7 @@ public:
     void code(tateyama::api::server::response_code code) override;
     tateyama::status body(std::string_view body) override;
     tateyama::status body_head(std::string_view body_head) override;
+    void error(proto::diagnostics::Record const& record) override;
     tateyama::status acquire_channel(std::string_view name, std::shared_ptr<tateyama::api::server::data_channel>& ch) override;
     tateyama::status release_channel(tateyama::api::server::data_channel& ch) override;
     tateyama::status close_session() override;

--- a/src/tateyama/endpoint/ipc/ipc_response.h
+++ b/src/tateyama/endpoint/ipc/ipc_response.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <string_view>
 #include <mutex>
+#include <atomic>
 
 #include <tateyama/api/server/response.h>
 #include <tateyama/api/server/response_code.h>
@@ -114,6 +115,8 @@ private:
     std::shared_ptr<ipc_data_channel> data_channel_{};
 
     std::size_t session_id_{};
+
+    std::atomic_flag completed_{};
 
     void server_diagnostics(std::string_view diagnostic_record);
 };

--- a/src/tateyama/endpoint/loopback/loopback_response.h
+++ b/src/tateyama/endpoint/loopback/loopback_response.h
@@ -74,8 +74,8 @@ public:
     }
 
     void error(proto::diagnostics::Record const& record) override {
-        // TODO implement
         (void) record;
+        throw std::runtime_error("tateyama::endpoint::loopback::loopback_response::error() is unimplemented");
     }
 
     /**

--- a/src/tateyama/endpoint/loopback/loopback_response.h
+++ b/src/tateyama/endpoint/loopback/loopback_response.h
@@ -73,6 +73,11 @@ public:
         return body_;
     }
 
+    void error(proto::diagnostics::Record const& record) override {
+        // TODO implement
+        (void) record;
+    }
+
     /**
      * @see tateyama::server::response::acquire_channel()
      */

--- a/src/tateyama/endpoint/stream/stream_response.cpp
+++ b/src/tateyama/endpoint/stream/stream_response.cpp
@@ -63,13 +63,19 @@ tateyama::status stream_response::body_head(std::string_view body_head) {
     return tateyama::status::ok;
 }
 
-void stream_response::error(proto::diagnostics::Record const&) {
-    //TODO implement
+void stream_response::error(proto::diagnostics::Record const& record) {
+    VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
+
+    std::string s{};
+    if(record.SerializeToString(&s)) {
+        server_diagnostics(s);
+    } else {
+        LOG_LP(ERROR) << "error formatting diagnostics message";
+        server_diagnostics("");
+    }
 }
 
 void stream_response::server_diagnostics(std::string_view diagnostic_record) {
-    VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
-
     std::stringstream ss{};
     endpoint::common::header_content arg{};
     arg.session_id_ = session_id_;

--- a/src/tateyama/endpoint/stream/stream_response.cpp
+++ b/src/tateyama/endpoint/stream/stream_response.cpp
@@ -63,6 +63,10 @@ tateyama::status stream_response::body_head(std::string_view body_head) {
     return tateyama::status::ok;
 }
 
+void stream_response::error(proto::diagnostics::Record const&) {
+    //TODO implement
+}
+
 void stream_response::server_diagnostics(std::string_view diagnostic_record) {
     VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
 

--- a/src/tateyama/endpoint/stream/stream_response.cpp
+++ b/src/tateyama/endpoint/stream/stream_response.cpp
@@ -47,10 +47,9 @@ tateyama::status stream_response::body(std::string_view body) {
         auto s = ss.str();
         session_socket_->send(index_, s, true);
         return tateyama::status::ok;
-    } else {
-        LOG_LP(ERROR) << "response is already completed";
-        return status::unknown;        
     }
+    LOG_LP(ERROR) << "response is already completed";
+    return status::unknown;        
 }
 
 tateyama::status stream_response::body_head(std::string_view body_head) {

--- a/src/tateyama/endpoint/stream/stream_response.cpp
+++ b/src/tateyama/endpoint/stream/stream_response.cpp
@@ -34,18 +34,23 @@ stream_response::stream_response(std::shared_ptr<tateyama::common::stream::strea
 }
 
 tateyama::status stream_response::body(std::string_view body) {
-    VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get()) << " length = " << body.length();  //NOLINT
+    if (!completed_.test_and_set()) {
+        VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get()) << " length = " << body.length();  //NOLINT
 
-    std::stringstream ss{};
-    endpoint::common::header_content arg{};
-    arg.session_id_ = session_id_;
-    if(auto res = endpoint::common::append_response_header(ss, body, arg); ! res) {
-        LOG_LP(ERROR) << "error formatting response message";
-        return status::unknown;
+        std::stringstream ss{};
+        endpoint::common::header_content arg{};
+        arg.session_id_ = session_id_;
+        if(auto res = endpoint::common::append_response_header(ss, body, arg); ! res) {
+            LOG_LP(ERROR) << "error formatting response message";
+            return status::unknown;
+        }
+        auto s = ss.str();
+        session_socket_->send(index_, s, true);
+        return tateyama::status::ok;
+    } else {
+        LOG_LP(ERROR) << "response is already completed";
+        return status::unknown;        
     }
-    auto s = ss.str();
-    session_socket_->send(index_, s, true);
-    return tateyama::status::ok;
 }
 
 tateyama::status stream_response::body_head(std::string_view body_head) {
@@ -64,14 +69,18 @@ tateyama::status stream_response::body_head(std::string_view body_head) {
 }
 
 void stream_response::error(proto::diagnostics::Record const& record) {
-    VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
+    if (!completed_.test_and_set()) {
+        VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
 
-    std::string s{};
-    if(record.SerializeToString(&s)) {
-        server_diagnostics(s);
+        std::string s{};
+        if(record.SerializeToString(&s)) {
+            server_diagnostics(s);
+        } else {
+            LOG_LP(ERROR) << "error formatting diagnostics message";
+            server_diagnostics("");
+        }
     } else {
-        LOG_LP(ERROR) << "error formatting diagnostics message";
-        server_diagnostics("");
+        LOG_LP(ERROR) << "response is already completed";
     }
 }
 

--- a/src/tateyama/endpoint/stream/stream_response.h
+++ b/src/tateyama/endpoint/stream/stream_response.h
@@ -19,6 +19,7 @@
 #include <string_view>
 #include <mutex>
 #include <condition_variable>
+#include <atomic>
 
 #include <tateyama/api/server/response.h>
 #include <tateyama/api/server/response_code.h>
@@ -103,6 +104,8 @@ private:
     std::shared_ptr<stream_data_channel> data_channel_{};
 
     std::size_t session_id_{};
+
+    std::atomic_flag completed_{};
 
     void server_diagnostics(std::string_view diagnostic_record);
 };

--- a/src/tateyama/endpoint/stream/stream_response.h
+++ b/src/tateyama/endpoint/stream/stream_response.h
@@ -85,6 +85,7 @@ public:
     void code(tateyama::api::server::response_code code) override;
     tateyama::status body(std::string_view body) override;
     tateyama::status body_head(std::string_view body_head) override;
+    void error(proto::diagnostics::Record const& record) override;
     tateyama::status acquire_channel(std::string_view name, std::shared_ptr<tateyama::api::server::data_channel>& ch) override;
     tateyama::status release_channel(tateyama::api::server::data_channel& ch) override;
     tateyama::status close_session() override;

--- a/test/tateyama/datastore/datastore_test.cpp
+++ b/test/tateyama/datastore/datastore_test.cpp
@@ -79,6 +79,7 @@ public:
         void code(api::server::response_code code) override {}
         status body_head(std::string_view body_head) override { return status::ok; }
         status body(std::string_view body) override { body_ = body;  return status::ok; }
+        void error(proto::diagnostics::Record const& record) override {}
         status acquire_channel(std::string_view name, std::shared_ptr<api::server::data_channel>& ch) override { return status::ok; }
         status release_channel(api::server::data_channel& ch) override { return status::ok; }
         status close_session() override { return status::ok; }

--- a/test/tateyama/framework/router_test.cpp
+++ b/test/tateyama/framework/router_test.cpp
@@ -103,6 +103,7 @@ public:
         void code(api::server::response_code code) override {}
         status body_head(std::string_view body_head) override { return status::ok; }
         status body(std::string_view body) override { body_ = body; return status::ok; }
+        void error(proto::diagnostics::Record const& record) override {}
         status acquire_channel(std::string_view name, std::shared_ptr<api::server::data_channel>& ch) override { return status::ok; }
         status release_channel(api::server::data_channel& ch) override { return status::ok; }
         status close_session() override { return status::ok; }


### PR DESCRIPTION
バージョン不整合等が発生した際にcore diagnosticsエラー情報をサービスがtateyamaに通知するためのAPIを追加します。