### PR TITLE
follow up on changes to log dir format in limestone

### DIFF
--- a/test/tateyama/datastore/datastore_test.cpp
+++ b/test/tateyama/datastore/datastore_test.cpp
@@ -124,7 +124,7 @@ TEST_F(datastore_test, basic) {
     ::tateyama::proto::datastore::response::BackupBegin bb{};
     EXPECT_TRUE(bb.ParseFromString(body));
     EXPECT_TRUE(bb.has_success());
-    EXPECT_EQ(1, bb.success().simple_source().files_size());
+    EXPECT_EQ(2, bb.success().simple_source().files_size());
     for(auto&& f : bb.success().simple_source().files()) {
         std::cout << "backup file: " << f << std::endl;
     }


### PR DESCRIPTION
永続化データにバージョンを導入し、それによりディレクトリの内容が変更されました。
tateyama で、backup 内容物を確認するテストがあり、これと不整合していたので、追従する修正です。

関連: https://github.com/project-tsurugi/tsurugi-issues/issues/418