### PR TITLE
remove close_session() from tateyama::api::server::response

### DIFF
--- a/include/tateyama/api/server/response.h
+++ b/include/tateyama/api/server/response.h
@@ -105,17 +105,6 @@ public:
      */
     virtual status release_channel(data_channel& ch) = 0;
 
-    /**
-     * @brief notify endpoint to close the current session
-     * @detail this function is called only in response to `disconnect` message to close the session
-     * @warning this function is temporary because endpoint requires the notification to ending session while
-     * the notion of session is still evolving. This function can be changed, or completely remove in the future.
-     * @return status::ok when successful
-     * @return other code when error occurs
-     * @attention this function is not thread-safe and should be called from single thread at a time.
-     */
-    virtual status close_session() = 0;
-
 };
 
 }

--- a/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
+++ b/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
@@ -546,9 +546,6 @@ public:
     garbage_collector* get_garbage_collector() override {
         return garbage_collector_impl_.get();
     }
-    void close_session() override { session_closed_ = true; }
-
-    [[nodiscard]] bool is_session_closed() const { return session_closed_; }
 
     // for client
     std::unique_ptr<resultset_wires_container_impl> create_resultset_wires_for_client(std::string_view name) {
@@ -562,7 +559,6 @@ private:
     response_wire_container_impl response_wire_{};
     status_provider* status_provider_{};
     std::unique_ptr<garbage_collector_impl> garbage_collector_impl_;
-    bool session_closed_{false};
     std::mutex mtx_shm_{};
 
     std::size_t datachannel_buffer_size_;

--- a/src/tateyama/endpoint/ipc/bootstrap/worker.cpp
+++ b/src/tateyama/endpoint/ipc/bootstrap/worker.cpp
@@ -37,7 +37,6 @@ void Worker::run()
                      static_cast<std::shared_ptr<tateyama::api::server::response>>(std::move(response)));
             request->dispose();
             request = nullptr;
-            if (wire_->is_session_closed()) { break; }
         } catch (std::runtime_error &e) {
             LOG_LP(ERROR) << e.what();
             break;

--- a/src/tateyama/endpoint/ipc/ipc_response.cpp
+++ b/src/tateyama/endpoint/ipc/ipc_response.cpp
@@ -121,13 +121,6 @@ tateyama::status ipc_response::release_channel(tateyama::api::server::data_chann
     return tateyama::status::unknown;
 }
 
-tateyama::status ipc_response::close_session() {
-    VLOG_LP(log_trace) << static_cast<const void*>(server_wire_.get());  //NOLINT
-
-    server_wire_->close_session();
-    return tateyama::status::ok;
-}
-
 // class ipc_data_channel
 tateyama::status ipc_data_channel::acquire(std::shared_ptr<tateyama::api::server::writer>& wrt) {
     try {

--- a/src/tateyama/endpoint/ipc/ipc_response.h
+++ b/src/tateyama/endpoint/ipc/ipc_response.h
@@ -96,7 +96,6 @@ public:
     void error(proto::diagnostics::Record const& record) override;
     tateyama::status acquire_channel(std::string_view name, std::shared_ptr<tateyama::api::server::data_channel>& ch) override;
     tateyama::status release_channel(tateyama::api::server::data_channel& ch) override;
-    tateyama::status close_session() override;
 
     void session_id(std::size_t id) override {
         session_id_ = id;

--- a/src/tateyama/endpoint/ipc/server_wires.h
+++ b/src/tateyama/endpoint/ipc/server_wires.h
@@ -106,7 +106,6 @@ public:
     virtual unq_p_resultset_wires_conteiner create_resultset_wires(std::string_view) = 0;
     virtual unq_p_resultset_wires_conteiner create_resultset_wires(std::string_view, std::size_t count) = 0;
     virtual garbage_collector* get_garbage_collector() = 0;
-    virtual void close_session() = 0;
 };
 inline server_wire_container::~server_wire_container() = default;
 inline server_wire_container::wire_container::~wire_container() = default;

--- a/src/tateyama/endpoint/loopback/loopback_response.h
+++ b/src/tateyama/endpoint/loopback/loopback_response.h
@@ -78,13 +78,6 @@ public:
      */
     tateyama::status release_channel(tateyama::api::server::data_channel &ch) override;
 
-    /**
-     * @see tateyama::server::response::close_session()
-     */
-    tateyama::status close_session() override {
-        return tateyama::status::ok;
-    }
-
     // just for unit test
     [[nodiscard]] std::map<std::string, std::vector<std::string>, std::less<>> const& all_committed_data() const noexcept {
         return committed_data_map_;

--- a/src/tateyama/endpoint/stream/stream_response.cpp
+++ b/src/tateyama/endpoint/stream/stream_response.cpp
@@ -126,13 +126,6 @@ tateyama::status stream_response::release_channel(tateyama::api::server::data_ch
 }
 
 
-// deprecated
-tateyama::status stream_response::close_session() {
-    VLOG_LP(log_trace) << static_cast<const void*>(session_socket_.get());  //NOLINT
-
-    return tateyama::status::ok;
-}
-
 // class stream_data_channel
 tateyama::status stream_data_channel::acquire(std::shared_ptr<tateyama::api::server::writer>& wrt) {
     try {

--- a/src/tateyama/endpoint/stream/stream_response.h
+++ b/src/tateyama/endpoint/stream/stream_response.h
@@ -87,7 +87,6 @@ public:
     void error(proto::diagnostics::Record const& record) override;
     tateyama::status acquire_channel(std::string_view name, std::shared_ptr<tateyama::api::server::data_channel>& ch) override;
     tateyama::status release_channel(tateyama::api::server::data_channel& ch) override;
-    tateyama::status close_session() override;
 
     void session_id(std::size_t id) override {
         session_id_ = id;

--- a/test/tateyama/datastore/datastore_test.cpp
+++ b/test/tateyama/datastore/datastore_test.cpp
@@ -81,7 +81,6 @@ public:
         void error(proto::diagnostics::Record const& record) override {}
         status acquire_channel(std::string_view name, std::shared_ptr<api::server::data_channel>& ch) override { return status::ok; }
         status release_channel(api::server::data_channel& ch) override { return status::ok; }
-        status close_session() override { return status::ok; }
 
         std::size_t session_id_{};
         std::string body_{};

--- a/test/tateyama/endpoint/loopback/loopback_response_test.cpp
+++ b/test/tateyama/endpoint/loopback/loopback_response_test.cpp
@@ -53,8 +53,6 @@ TEST_F(loopback_response_test, set_get) {
     EXPECT_EQ(response.body(), body);
     EXPECT_EQ(response.body_head(), body_head);
     //
-    EXPECT_EQ(response.close_session(), tateyama::status::ok);
-    //
     EXPECT_EQ(response.session_id(), session_id);
     EXPECT_EQ(response.body(), body);
     EXPECT_EQ(response.body_head(), body_head);
@@ -201,8 +199,6 @@ TEST_F(loopback_response_test, empty_channel_name) {
     for (int i = 0; i < result.size(); i++) {
         EXPECT_EQ(result[i], test_data[i]);
     }
-    //
-    EXPECT_EQ(response.close_session(), tateyama::status::ok);
 }
 
 inline void dummy_message(int i, int j, std::string &s) {

--- a/test/tateyama/framework/router_test.cpp
+++ b/test/tateyama/framework/router_test.cpp
@@ -105,7 +105,6 @@ public:
         void error(proto::diagnostics::Record const& record) override {}
         status acquire_channel(std::string_view name, std::shared_ptr<api::server::data_channel>& ch) override { return status::ok; }
         status release_channel(api::server::data_channel& ch) override { return status::ok; }
-        status close_session() override { return status::ok; }
 
         std::size_t session_id_{};
         std::string body_{};


### PR DESCRIPTION
tateyama::api::server::responseに用意していたclose_session()は使わなくなっているので削除します。