### PR TITLE
doc: revise monitoring spec to show error causes.

### DIFF
--- a/docs/cli-monitor-ja.md
+++ b/docs/cli-monitor-ja.md
@@ -73,6 +73,7 @@
 | `kind` | `finish` |
 | `status` | `success`, `failure` |
 | `reason` | 原因コード (任意) |
+| `cause` | 原因情報 (配列型, 任意) |
 | `message` | メッセージ (任意) |
 | `code` | コード (任意) |
 | `arguments` | コードに対する引数列 (配列型, 任意) |


### PR DESCRIPTION
This PR introduced a new spec to CLI monitoring, `cause` into the `finish` record.
It will improve to obtain error causes, like Java exception chain.