### PR TITLE
explicitly discarding return value of release_FOO (for FTBFS with protobuf v3.17.0)

### DIFF
--- a/src/tateyama/debug/service.cpp
+++ b/src/tateyama/debug/service.cpp
@@ -67,7 +67,7 @@ static void reply_error(std::string_view error_message,
     error.set_message(std::string(error_message));
     logging.set_allocated_unknown_error(&error);
     reply(logging, res);
-    logging.release_unknown_error();
+    (void)logging.release_unknown_error();
 }
 
 static void success_logging(std::shared_ptr<tateyama::api::server::response> &res) {
@@ -75,7 +75,7 @@ static void success_logging(std::shared_ptr<tateyama::api::server::response> &re
     tateyama::proto::debug::response::Void v { };
     logging.set_allocated_success(&v);
     reply(logging, res);
-    logging.release_success();
+    (void)logging.release_success();
 }
 
 static void command_logging(tateyama::proto::debug::request::Request &proto_req,


### PR DESCRIPTION
protobuf の新しいバージョンで、生成されるコードの `release_ナントカ` 関数に `[[nodiscard]]` がつくようになったため、警告が出るようになりました。
jogasaki や tateyama は `-Werror` しているためビルドが失敗してしまいます。
それの対応になります。

目視で確認し、処理に問題のありそうな点は別途直してもらい (#161)、残りはすべて返値を捨てても問題なさそうであることを確認しました。

```
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp: In function 'void tateyama:
:debug::reply_error(std::string_view, std::shared_ptr<tateyama::api::server::response>&)':
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp:70:34: error: ignoring retur
n value of 'tateyama::proto::debug::response::UnknownError* tateyama::proto::debug::response::Logging::release_unknown_error()', declared with attribute 'nodiscard' [-Werror=unused-result]
   70 |     logging.release_unknown_error();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp:22:
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/build/src/tateyama/proto/debug/response.pb.h:703:58: note: declared here
  703 | inline ::tateyama::proto::debug::response::UnknownError* Logging::release_unknown_error() {
      |                                                          ^~~~~~~
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp: In function 'void tateyama::debug::success_logging(std::shared_ptr<tateyama::api::server::response>&)':
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp:78:28: error: ignoring return value of 'tateyama::proto::debug::response::Void* tateyama::proto::debug::response::Logging::release_success()', declared with attribute 'nodiscard' [-Werror=unused-result]
   78 |     logging.release_success();
      |     ~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/src/tateyama/debug/service.cpp:22:
/home/ban/src/tsurugi-snapshot-202312250242-916c16d/tateyama/build/src/tateyama/proto/debug/response.pb.h:629:50: note: declared here
  629 | inline ::tateyama::proto::debug::response::Void* Logging::release_success() {
      |                                                  ^~~~~~~
cc1plus: all warnings being treated as errors
```