### PR TITLE
Fix invalid service id handling

### DIFF
--- a/include/tateyama/loopback/buffered_response.h
+++ b/include/tateyama/loopback/buffered_response.h
@@ -48,7 +48,7 @@ public:
      * @param session_id session identifier of the response
      * @param error_rec error information record
      */
-    buffered_response(std::size_t session_id, proto::diagnostics::Record const& error_rec);
+    buffered_response(std::size_t session_id, proto::diagnostics::Record error_rec);
 
     /**
      * @brief accessor to the session identifier

--- a/include/tateyama/loopback/buffered_response.h
+++ b/include/tateyama/loopback/buffered_response.h
@@ -44,6 +44,13 @@ public:
             std::string_view body, std::map<std::string, std::vector<std::string>, std::less<>> &&data_map);
 
     /**
+     * @brief create response object
+     * @param session_id session identifier of the response
+     * @param error_rec error information record
+     */
+    buffered_response(std::size_t session_id, proto::diagnostics::Record const& error_rec);
+
+    /**
      * @brief accessor to the session identifier
      * @return session identifier of this response
      */
@@ -78,11 +85,18 @@ public:
      */
     [[nodiscard]] std::vector<std::string> const& channel(std::string_view name) const;
 
+    /**
+     * @brief accessor to the error information
+     * @return error information object
+     */
+    [[nodiscard]] proto::diagnostics::Record const& error() const noexcept;
+
 private:
     std::size_t session_id_ { };
     std::string body_head_ { };
     std::string body_ { };
     std::map<std::string, std::vector<std::string>, std::less<>> data_map_ { };
+    proto::diagnostics::Record error_rec_ { };
 };
 
 } // namespace tateyama::loopback

--- a/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
+++ b/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
@@ -29,9 +29,8 @@ tateyama::loopback::buffered_response loopback_endpoint::request(std::size_t ses
     if (service_->operator ()(std::move(request), response)) {
         return tateyama::loopback::buffered_response { response->session_id(), response->body_head(),
                 response->body(), response->release_all_committed_data() };
-    } else {
-        return tateyama::loopback::buffered_response { response->session_id(), response->error() };
     }
+    return tateyama::loopback::buffered_response { response->session_id(), response->error() };
 }
 
 } // namespace tateyama::endpoint::loopback

--- a/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
+++ b/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
@@ -29,8 +29,9 @@ tateyama::loopback::buffered_response loopback_endpoint::request(std::size_t ses
     if (service_->operator ()(std::move(request), response)) {
         return tateyama::loopback::buffered_response { response->session_id(), response->body_head(),
                 response->body(), response->release_all_committed_data() };
+    } else {
+        return tateyama::loopback::buffered_response { response->session_id(), response->error() };
     }
-    throw std::invalid_argument("unknown service_id " + std::to_string(service_id));
 }
 
 } // namespace tateyama::endpoint::loopback

--- a/src/tateyama/endpoint/loopback/loopback_response.h
+++ b/src/tateyama/endpoint/loopback/loopback_response.h
@@ -62,9 +62,15 @@ public:
         return body_;
     }
 
+    /**
+     * @see tateyama::server::response::error()
+     */
     void error(proto::diagnostics::Record const& record) override {
-        (void) record;
-        throw std::runtime_error("tateyama::endpoint::loopback::loopback_response::error() is unimplemented");
+        error_rec_ = record;
+    }
+
+    [[nodiscard]] proto::diagnostics::Record const& error() const noexcept {
+        return error_rec_;
     }
 
     /**
@@ -96,6 +102,7 @@ private:
     std::size_t session_id_ { };
     std::string body_head_ { };
     std::string body_ { };
+    proto::diagnostics::Record error_rec_ { };
 
     std::mutex mtx_channel_map_ { };
     /*

--- a/src/tateyama/loopback/buffered_response.cpp
+++ b/src/tateyama/loopback/buffered_response.cpp
@@ -23,8 +23,8 @@ buffered_response::buffered_response(std::size_t session_id,
         session_id_(session_id), body_head_(body_head), body_(body), data_map_(std::move(data_map)) {
 }
 
-buffered_response::buffered_response(std::size_t session_id, proto::diagnostics::Record const& error_rec) :
-    session_id_(session_id), error_rec_(error_rec) {
+buffered_response::buffered_response(std::size_t session_id, proto::diagnostics::Record error_rec) :
+    session_id_(session_id), error_rec_(std::move(error_rec)) {
 }
 
 std::size_t buffered_response::session_id() const noexcept {

--- a/src/tateyama/loopback/buffered_response.cpp
+++ b/src/tateyama/loopback/buffered_response.cpp
@@ -23,6 +23,10 @@ buffered_response::buffered_response(std::size_t session_id,
         session_id_(session_id), body_head_(body_head), body_(body), data_map_(std::move(data_map)) {
 }
 
+buffered_response::buffered_response(std::size_t session_id, proto::diagnostics::Record const& error_rec) :
+    session_id_(session_id), error_rec_(error_rec) {
+}
+
 std::size_t buffered_response::session_id() const noexcept {
     return session_id_;
 }
@@ -45,6 +49,10 @@ std::vector<std::string> const& buffered_response::channel(std::string_view name
         return it->second;
     }
     throw std::invalid_argument("invalid channel name: " + std::string { name });
+}
+
+proto::diagnostics::Record const& buffered_response::error() const noexcept {
+    return error_rec_;
 }
 
 } // namespace tateyama::loopback


### PR DESCRIPTION
不正なサービスIDで要求が来たときの処理を全面的に直しました。
・loopback_responseとbuffered_responseがエラー情報を設定・取得できるようにしました（修正前は未対応例外スローあり）
・loopback_endpointが、不正なサービスID要求の際に、そのエラー情報をレスポンスに設定するようにしました（修正前は例外スロー）
・loopback_client_testで、不正サービスID要求後に、エラー情報を取得・チェックするようにしました（修正前は例外キャッチ）