### PR TITLE
Fix invalid service id handling

### DIFF
--- a/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
+++ b/src/tateyama/endpoint/loopback/loopback_endpoint.cpp
@@ -30,7 +30,7 @@ tateyama::loopback::buffered_response loopback_endpoint::request(std::size_t ses
         return tateyama::loopback::buffered_response { response->session_id(), response->body_head(),
                 response->body(), response->release_all_committed_data() };
     }
-    return tateyama::loopback::buffered_response { response->session_id(), response->error() };
+    return tateyama::loopback::buffered_response { session_id, response->error() };
 }
 
 } // namespace tateyama::endpoint::loopback

--- a/test/tateyama/loopback/loopback_client_test.cpp
+++ b/test/tateyama/loopback/loopback_client_test.cpp
@@ -125,6 +125,9 @@ TEST_F(loopback_client_test, single) {
     EXPECT_EQ(response.session_id(), session_id);
     EXPECT_EQ(response.body_head(), data_channel_service::body_head);
     EXPECT_EQ(response.body(), request);
+    auto &error_rec = response.error();
+    EXPECT_EQ(error_rec.code(), 0);
+    EXPECT_TRUE(error_rec.message().empty());
     //
     for (int ch = 0; ch < nchannel; ch++) {
         std::string name { std::move(data_channel_service::channel_name(ch)) };
@@ -166,6 +169,9 @@ TEST_F(loopback_client_test, multi_request) {
         EXPECT_EQ(response.session_id(), session_id);
         EXPECT_EQ(response.body_head(), data_channel_service::body_head);
         EXPECT_EQ(response.body(), request);
+        auto &error_rec = response.error();
+        EXPECT_EQ(error_rec.code(), 0);
+        EXPECT_TRUE(error_rec.message().empty());
         //
         for (int ch = 0; ch < nchannel; ch++) {
             std::string name { std::move(data_channel_service::channel_name(ch)) };
@@ -201,6 +207,9 @@ TEST_F(loopback_client_test, unknown_service_id) {
     ASSERT_TRUE(sv.start());
     //
     const auto response = loopback.request(session_id, invalid_service_id, request);
+    EXPECT_EQ(response.session_id(), session_id);
+    EXPECT_TRUE(response.body_head().empty());
+    EXPECT_TRUE(response.body().empty());
     auto &error_rec = response.error();
     EXPECT_EQ(tateyama::proto::diagnostics::Code::SERVICE_UNAVAILABLE, error_rec.code());
     auto msg = error_rec.message();


### PR DESCRIPTION
テストでのチェック項目を追加しました。
・要求成功時にエラー情報が空であること
・要求エラー時にメッセージボディーなどが空であること
このテスト追加で、要求エラー時にセッションIDが正しく設定されていないバグを見つけましたので、合わせて直しました。