### PR TITLE
build: add build option `ENABLE_DEBUG_SERVICE`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static" ON)
 option(ENABLE_CACHE_ALIGN "enable optional cache align requirement" OFF)
 option(MC_QUEUE "use moody-camel queue" OFF)
 option(TRACY_ENABLE "enable tracy profiler" OFF)
+option(ENABLE_DEBUG_SERVICE "treats debug service as a core component" ON)
 option(ENABLE_ALTIMETER "enable altimeter logging" OFF)
 
 if(NOT DEFINED SHARKSFIN_IMPLEMENTATION)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ available options:
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `memory`)
 * `-DPERFORMANCE_TOOLS=ON` - enable performance tooling to measure engine performance
 * `-DMC_QUEUE=ON` - use moody camel queue instead of tbb queue to store tasks in tateyama task scheduler.
+* `-DENABLE_DEBUG_SERVICE=OFF` - turn off the `debug service`.
 * for debugging only
   * `-DENABLE_SANITIZER=OFF` - disable sanitizers (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DENABLE_UB_SANITIZER=ON` - enable undefined behavior sanitizer (requires `-DENABLE_SANITIZER=ON`)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,10 @@ if(MC_QUEUE)
     target_compile_definitions(${ENGINE} PUBLIC MC_QUEUE)
 endif()
 
+if (ENABLE_DEBUG_SERVICE)
+    target_compile_definitions(${ENGINE} PRIVATE ENABLE_DEBUG_SERVICE)
+endif ()
+
 if (ENABLE_ALTIMETER)
     target_link_libraries(${ENGINE}
         PRIVATE altimeter

--- a/src/tateyama/framework/server.cpp
+++ b/src/tateyama/framework/server.cpp
@@ -156,7 +156,9 @@ void add_core_components(server& svr) {
 
     svr.add_service(std::make_shared<framework::routing_service>());
     svr.add_service(std::make_shared<datastore::service::bridge>());
+#ifdef ENABLE_DEBUG_SERVICE
     svr.add_service(std::make_shared<debug::service>());
+#endif
 
     svr.add_endpoint(std::make_shared<framework::ipc_endpoint>());
     svr.add_endpoint(std::make_shared<framework::stream_endpoint>());


### PR DESCRIPTION
This PR introduces a new CMake build option `ENABLE_DEBUG_SERVICE` (default: `ON`).
It is whether to treat the debug service as a core component, that is, whether to enable the service in the standard tsurugidb install package.