### PR TITLE
implement altimeter audit log output for backup and restore

### DIFF
--- a/include/tateyama/altimeter/events.h
+++ b/include/tateyama/altimeter/events.h
@@ -52,13 +52,18 @@ static constexpr int info = 50;
 namespace log_type::audit {
 static constexpr std::string_view db_start = "db_start";
 static constexpr std::string_view db_stop = "db_stop";
+static constexpr std::string_view backup = "backup";
+static constexpr std::string_view restore = "restore";
 } // namespace log_type::audit
 
 // audit log item list
 namespace log_item::audit {
 static constexpr std::string_view user = "user";
 static constexpr std::string_view dbname = "dbname";
+static constexpr std::string_view remote_host = "remote_host";
+static constexpr std::string_view application_name = "application_name";
 static constexpr std::string_view result = "result";
+static constexpr std::string_view command = "command";
 }
 
 // audit log level list

--- a/src/tateyama/datastore/service/altimeter_logger.h
+++ b/src/tateyama/datastore/service/altimeter_logger.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <altimeter/configuration.h>
+#include <altimeter/log_item.h>
+#include <altimeter/logger.h>
+
+#include <tateyama/altimeter/events.h>
+
+namespace tateyama::datastore::service {
+
+using namespace tateyama::altimeter;
+
+static constexpr std::int64_t backup_restore_success = 1;
+static constexpr std::int64_t backup_restore_fail = 2;
+
+static inline void backup(const std::shared_ptr<request>& req, std::string_view command, std::int64_t result) {
+    if (::altimeter::logger::is_log_on(log_category::audit, log_level::audit::info)) {
+        ::altimeter::log_item log_item;
+        log_item.category(log_category::audit);
+        log_item.type(log_type::audit::backup);
+        log_item.level(log_level::audit::info);
+        if (auto user = req->session_info().user_name(); !user.empty()) {
+            log_item.add(log_item::audit::user, user);
+        }
+        if (auto dbname = req->database_info().name(); !dbname.empty()) {
+            log_item.add(log_item::audit::dbname, dbname);
+        }
+        if (auto connection_information = req->session_info().connection_information(); !connection_information.empty()) {
+            log_item.add(log_item::event::remote_host, connection_information);
+        }
+        if (auto application_name = req->session_info().application_name(); !application_name.empty()) {
+            log_item.add(log_item::event::application_name, application_name);
+        }
+        log_item.add(log_item::audit::result, result);
+        if (!command.empty()) {
+            log_item.add(log_item::audit::command, command);
+        }
+        ::altimeter::logger::log(log_item);
+    }
+}
+
+static inline void restore(const std::shared_ptr<request>& req, std::string_view command, std::int64_t result) {
+    if (::altimeter::logger::is_log_on(log_category::audit, log_level::audit::info)) {
+        ::altimeter::log_item log_item;
+        log_item.category(log_category::audit);
+        log_item.type(log_type::audit::restore);
+        log_item.level(log_level::audit::info);
+        if (auto user = req->session_info().user_name(); !user.empty()) {
+            log_item.add(log_item::audit::user, user);
+        }
+        if (auto dbname = req->database_info().name(); !dbname.empty()) {
+            log_item.add(log_item::audit::dbname, dbname);
+        }
+        if (auto connection_information = req->session_info().connection_information(); !connection_information.empty()) {
+            log_item.add(log_item::event::remote_host, connection_information);
+        }
+        if (auto application_name = req->session_info().application_name(); !application_name.empty()) {
+            log_item.add(log_item::event::application_name, application_name);
+        }
+        log_item.add(log_item::audit::result, result);
+        if (!command.empty()) {
+            log_item.add(log_item::audit::command, command);
+        }
+        ::altimeter::logger::log(log_item);
+    }
+}
+
+}

--- a/src/tateyama/datastore/service/core.cpp
+++ b/src/tateyama/datastore/service/core.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@
 
 #include <tateyama/proto/datastore/request.pb.h>
 #include <tateyama/proto/datastore/response.pb.h>
+#ifdef ENABLE_ALTIMETER
+#include "altimeter_logger.h"
+#endif
 
 
 namespace tateyama::datastore::service {
@@ -45,6 +48,9 @@ bool tateyama::datastore::service::core::operator()(const std::shared_ptr<reques
         case ns::Request::kBackupBegin: {
             backup_id_++;
             backup_ = std::make_unique<limestone_backup>(resource_->begin_backup());
+#ifdef ENABLE_ALTIMETER
+            service::backup(req, "classic", backup_restore_success);
+#endif
 
             tateyama::proto::datastore::response::BackupBegin rp{};
             auto success = rp.mutable_success();
@@ -65,6 +71,9 @@ bool tateyama::datastore::service::core::operator()(const std::shared_ptr<reques
                 limestone::api::backup_type::standard :
                 limestone::api::backup_type::transaction;
             backup_detail_ = resource_->begin_backup(type);
+#ifdef ENABLE_ALTIMETER
+            service::backup(req, "prusik", backup_restore_success);
+#endif
 
             tateyama::proto::datastore::response::BackupBegin rp{};
             auto success = rp.mutable_success();
@@ -174,6 +183,11 @@ bool tateyama::datastore::service::core::operator()(const std::shared_ptr<reques
                 rp.mutable_unknown_error();
                 break;
             }
+#ifdef ENABLE_ALTIMETER
+            service::restore(req,
+                    rb.source_case() == ns::RestoreBegin::kBackupDirectory ? "classic" : "prusik",
+                    rc == limestone::status::ok ? backup_restore_success : backup_restore_fail);
+#endif
             res->session_id(this_request_does_not_use_session_id);
             auto body = rp.SerializeAsString();
             res->body(body);


### PR DESCRIPTION
backup, restore に対する audit_log の実装を追加しました。

案件: https://github.com/project-tsurugi/tsurugi-issues/issues/622

注意点
* `command` に埋める値は仮のものです
* `dbname`, `application_name`, `remote_host` については tateyama の既存コードを参考にし、同様の値を使用するようにしています
    * tgctl からの接続に対して `application_name:2011563` などという値が埋まります
 * backup はサーバ側では常に成功するため、常に `result:1` となります