### PR TITLE
fix leak around release_message() call

### DIFF
--- a/src/tateyama/endpoint/common/worker_common.h
+++ b/src/tateyama/endpoint/common/worker_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,6 @@ protected:
         record.set_code(code);
         record.set_message(message);
         res->error(record);
-        record.release_message();
     }
 
     bool endpoint_service(const std::shared_ptr<tateyama::api::server::request>& req,


### PR DESCRIPTION
protobuf の新しいバージョンで、生成されるコードの `release_message()` 関数に `[[nodiscard]]` がつくようになったため、コンパイル時に警告が出るようになり、加えて tateyama は `-Werror` しているためビルドが失敗してしまうため、調査しました。

message は `set_message(const std::string&)` で渡したものを `Record`内部にコピーして格納しており、これを release すると `Record` の string を切り離して新規に `new std::string` に格納したものを返してくるため、release の返値をそのままにするとリークが発生します。
release しなければ `Record` dtor の内部で破棄処理されるため、それに任せることにしました。