### PR TITLE
Improve TCP connection by buffering data for faster writes

### DIFF
--- a/src/tateyama/endpoint/stream/stream_response.h
+++ b/src/tateyama/endpoint/stream/stream_response.h
@@ -48,6 +48,14 @@ private:
     std::shared_ptr<stream_socket> stream_;
     std::uint16_t slot_;
     unsigned char writer_id_;
+    std::vector<char> buffer_;
+    /**
+     * @brief Buffer size for storing stream data.
+     *
+     * This constant defines the buffer size of 64KB used for temporary storage
+     * of stream data before sending it.
+     */
+    static constexpr std::size_t buffer_size = 65536;
 };
 
 /**


### PR DESCRIPTION
Improve of [#882](https://github.com/project-tsurugi/tsurugi-issues/issues/882) Buffer data sent over TCP connections to improve write performance.