### PR TITLE
add sql.scan_block_size config. param.

### DIFF
--- a/docs/config-parameters-en.md
+++ b/docs/config-parameters-en.md
@@ -71,6 +71,7 @@ Target component
 | dev_point_read_concurrent_operation_as_not_found | Boolean (true/false) | Whether to treat records detected as concurrently inserted during point read operations (WARN_CONCURRENT_INSERT) as non-existent. The default value is true. | This is for development and may be deleted in the future. |
 |dev_compiler_support| Integer | The support level of SQL compiler. Use old compiler if this is set to 0 and new one if 1. The default value is 1. |This is for development and may be deleted in the future.|
 |lowercase_regular_identifiers| Boolean (true/false) | Whether to lowercase the identifiers such as table names. This configuration is available only on new SQL compiler. The default value is false.||
+|scan_block_size| Integer | Max records processed by scan operator before yielding to other tasks. The default is 0 (unlimited). | This is for development and may be deleted in the future. |
 
 ## ipc_endpoint section
 

--- a/docs/config_parameters.md
+++ b/docs/config_parameters.md
@@ -71,7 +71,7 @@ parameter=value
 |dev_point_read_concurrent_operation_as_not_found| ブール(true/false) | ポイントリード操作において並列して挿入されたレコードを検知した際(WARN_CONCURRENT_INSERT)に、そのレコードが存在しないものとして取り扱うか。デフォルトはtrue|開発用のため将来的に削除される可能性あり|
 |dev_compiler_support| 整数 | SQLコンパイラのサポートレベル。0の場合は旧コンパイラを使用、1の場合は新コンパイラを使用する。デフォルトは1|開発用のため将来的に削除/変更される可能性あり|
 |lowercase_regular_identifiers| ブール(true/false) | SQLコンパイラがテーブル名などのシンボルを小文字に変換して扱うか。新コンパイラのみ有効。デフォルトはfalse||
-
+|scan_block_size| 整数 | スキャンが他のタスクにスレッドを譲渡する前に処理するレコードの最大数。デフォルトは0(無制限)|開発用のため将来的に削除/変更される可能性あり|
 ## ipc_endpointセクション
 
 セクション名

--- a/include/tateyama/task_scheduler/task_scheduler_cfg.h
+++ b/include/tateyama/task_scheduler/task_scheduler_cfg.h
@@ -179,6 +179,14 @@ public:
         worker_suspend_timeout_ = arg;
     }
 
+    [[nodiscard]] std::size_t scan_block_size() const noexcept {
+        return scan_block_size_;
+    }
+
+    void scan_block_size(std::size_t arg) noexcept {
+        scan_block_size_ = arg;
+    }
+
     friend inline std::ostream& operator<<(std::ostream& out, task_scheduler_cfg const& cfg) {
         return out << std::boolalpha <<
             "thread_count:" << cfg.thread_count() << " " <<
@@ -195,6 +203,7 @@ public:
             "watcher_interval:" << cfg.watcher_interval() << " " <<
             "worker_try_count:" << cfg.worker_try_count() << " " <<
             "worker_suspend_timeout:" << cfg.worker_suspend_timeout() << " " <<
+            "scan_block_size:" << cfg.scan_block_size() << " " <<
             "";
     }
 
@@ -213,6 +222,7 @@ private:
     std::size_t watcher_interval_ = 1000;
     std::size_t worker_try_count_ = 1000;
     std::size_t worker_suspend_timeout_ = 1000000;
+    std::size_t scan_block_size_ = 0;
 };
 
 }


### PR DESCRIPTION
This PR introduces a change to the tsurugi.ini configuration file to allow modification of the scan_block_size parameter. This change is intended to facilitate investigation of issue [#706](https://github.com/project-tsurugi/tsurugi-issues/issues/706) by enabling dynamic adjustment of the scan_block_size value