### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -58,7 +58,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -88,7 +88,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -98,7 +98,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 

--- a/.vscode/samples/settings.json
+++ b/.vscode/samples/settings.json
@@ -1,7 +1,6 @@
 {
     "cmake.configureArgs": [
         "-DCMAKE_PREFIX_PATH=${env:HOME}/git/.opt",
-        "-DFORCE_INSTALL_RPATH=ON",
         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
         "-DCMAKE_BUILD_TYPE=${env:BUILD_TYPE}",
         "-DSHARKSFIN_IMPLEMENTATION=${env:SHARKSFIN_IMPLEMENTATION}",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ optional packages:
 This requires below [tsurugidb](https://github.com/project-tsurugi/tsurugidb) modules to be installed.
 
 * [takatori](https://github.com/project-tsurugi/takatori)  (for takatori::util functionalities)
-* [sharksfin](https://github.com/project-tsurugi/sharksfin) 
+* [sharksfin](https://github.com/project-tsurugi/sharksfin)
 
 #### moodycamel::ConcurrentQueue
 
@@ -63,7 +63,6 @@ available options:
 * `-DBUILD_DOCUMENTS=OFF` - don't build documents by doxygen
 * `-DINSTALL_EXAMPLES=ON` - install example applications
 * `-DBUILD_BENCHMARK=ON` - build benchmark programs
-* `-DFORCE_INSTALL_RPATH=ON` - automatically configure `INSTALL_RPATH` for non-default library paths
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `memory`)
 * `-DENABLE_ALTIMETER=ON` - turn on the `altimeter logging`.
 * `-DMC_QUEUE=ON` - use moody camel queue instead of tbb queue to store tasks in tateyama task scheduler.
@@ -74,7 +73,7 @@ available options:
   * `-DENABLE_COVERAGE=ON` - enable code coverage analysis (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DTRACY_ENABLE=ON` - enable tracy profiler for multi-thread debugging. See section below.
 
-### install 
+### install
 
 ```sh
 cmake --build . --target install
@@ -93,11 +92,11 @@ ctest -V
 cmake --build . --target doxygen
 ```
 
-### Customize logging setting 
+### Customize logging setting
 You can customize logging in the same way as sharksfin. See sharksfin [README.md](https://github.com/project-tsurugi/sharksfin/blob/master/README.md#customize-logging-setting) for more details.
 
 ```sh
-GLOG_minloglevel=0 ./group-cli --minimum 
+GLOG_minloglevel=0 ./group-cli --minimum
 ```
 
 ### Multi-thread debugging/profiling with Tracy
@@ -105,7 +104,7 @@ GLOG_minloglevel=0 ./group-cli --minimum
 You can use [Tracy Profiler](https://github.com/wolfpld/tracy) to graphically display the threads operations and improve printf debug by printing messages on the tooltips on the Tracy profiler UI.
 By setting cmake build option `-DTRACY_ENABLE=ON`, TracyClient.cpp file is added to the build and tracing macros are enabled.
 
-Prerequirement: 
+Prerequirement:
 
 1. ensure tracy code is located under `third_party/tracy` directory.
 ```

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -14,37 +14,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/examples/task_scheduler_cli/CMakeLists.txt
+++ b/examples/task_scheduler_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(task-scheduler-cli
 
 set_target_properties(task-scheduler-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "task-scheduler-cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "task-scheduler-cli"
 )
 
 target_include_directories(task-scheduler-cli

--- a/examples/thread_affinity_cli/CMakeLists.txt
+++ b/examples/thread_affinity_cli/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(thread-affinity-cli
 
 set_target_properties(thread-affinity-cli
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "cli"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "cli"
 )
 
 target_include_directories(thread-affinity-cli

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,9 +75,11 @@ add_dependencies(${ENGINE}
         build_protos
         )
 
-set_target_properties(${ENGINE} PROPERTIES
-        OUTPUT_NAME ${export_name}
-        )
+set_target_properties(${ENGINE}
+        PROPERTIES
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                OUTPUT_NAME ${export_name}
+)
 
 target_include_directories(${ENGINE}
         PRIVATE


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.