### PR TITLE
remove transitive dependency from takatori

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Project Tsurugi.
+# Copyright 2018-2024 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ find_package(glog REQUIRED)
 find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost
-        COMPONENTS filesystem thread system container stacktrace_backtrace
+        COMPONENTS filesystem thread system container
         REQUIRED
         )
 find_package(TBB REQUIRED)


### PR DESCRIPTION
takatori は Boost::stacktrace_backtrace へ依存していましたが、推移的依存関係の設定がうまくされていなかったため、 takatori を使う側でも Boost::stacktrace_backtrace への依存を明示的に記述しないとビルドが通らなくなっていました。

上記の問題は project-tsurugi/takatori#40 で修正したので、現在記述されている Boost::stacktrace_backtrace への依存を除去します。
(takatori が Boost::stacktrace_backtrace に依存しなくなったときに邪魔になります)