### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/examples/task_scheduler_cli/CMakeLists.txt
+++ b/examples/task_scheduler_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(task-scheduler-cli
 
 set_target_properties(task-scheduler-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "task-scheduler-cli"
 )
 

--- a/examples/thread_affinity_cli/CMakeLists.txt
+++ b/examples/thread_affinity_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(thread-affinity-cli
 
 set_target_properties(thread-affinity-cli
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "cli"
 )
 

--- a/mock/CMakeLists.txt
+++ b/mock/CMakeLists.txt
@@ -35,7 +35,7 @@ add_dependencies(mock_server
 
 set_target_properties(mock_server
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "mock_server"
         )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ add_dependencies(${ENGINE}
 
 set_target_properties(${ENGINE}
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 OUTPUT_NAME ${export_name}
 )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、 INSTALL_RPATH で指定している場所と異なり起動時に問題となることがあります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。

以上に加えて、 add_executable される mock_server に対して `INSTALL_RPATH "\$ORIGIN"` が指定されていましたが、これは `bin` 下にインストールされ、そこから libdir を見に行く必要があるはずですので、 libdir を指すように修正を加えました。