### PR TITLE
`build` 以外の名前でビルドディレクトリを作成した場合のビルドエラー

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,7 +96,7 @@ register_tests(
     TARGET tateyama
     INCLUDES
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${PROJECT_SOURCE_DIR}/build/src
+        ${CMAKE_BINARY_DIR}/src
     DEPENDS
         tateyama-impl
         limestone


### PR DESCRIPTION
コミット https://github.com/project-tsurugi/tateyama/commit/add2cc5ef3ad29c7ae2b3c90927b68f5d21027fd で追加されたファイルにビルドディレクトリに関する前提が含まれていたようで、`build` という名前以外でディレクトリを作成してビルドしようとすると下記のようなエラーになります。その修正案です。

```
[188/195] Building CXX object test/CMakeFiles/tateyama-tes...ateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp.o
FAILED: test/CMakeFiles/tateyama-test_ipc_resultset_writer_limit_test.dir/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp.o
ccache /usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTAINER_DYN_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_ENABLE_ASSERT_DEBUG_HANDLER -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_STACKTRACE_BACKTRACE_DYN_LINK -DBOOST_STACKTRACE_BACKTRACE_NO_LIB -DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_VERSION=4 -DCC_SILO_VARIANT -DENABLE_ALTIMETER -DTBB_USE_GLIBCXX_VERSION=130300 -I/home/kuro/git/tateyama/test -I/home/kuro/git/tateyama/build/src -I/home/kuro/git/tateyama/src/. -I/home/kuro/git/tateyama/include -I/home/kuro/git/.local-debug/include -isystem /home/kuro/git/.local-debug/include/sharksfin -isystem /home/kuro/git/.local-debug/include/takatori -isystem /home/kuro/git/.opt/include -isystem /home/kuro/git/.local-debug/include/limestone -isystem /home/kuro/git/tateyama/third_party/googletest/googletest/include -isystem /home/kuro/git/tateyama/third_party/googletest/googletest -g -fno-omit-frame-pointer -fsanitize=address -fno-sanitize=alignment -fno-sanitize-recover=address -std=c++17 -fdiagnostics-color=always -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function -Wno-unused-variable -DSORT_METHOD_USE_ROCKSDB -MD -MT test/CMakeFiles/tateyama-test_ipc_resultset_writer_limit_test.dir/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp.o -MF test/CMakeFiles/tateyama-test_ipc_resultset_writer_limit_test.dir/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp.o.d -o test/CMakeFiles/tateyama-test_ipc_resultset_writer_limit_test.dir/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp.o -c /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp
In file included from /home/kuro/git/tateyama/include/tateyama/framework/service.h:24,
                 from /home/kuro/git/tateyama/include/tateyama/datastore/service/bridge.h:22,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_test_utils.h:24,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_test_env.h:19,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_gtest_base.h:18,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_resultset_writer_limit_test.cpp:16:
/home/kuro/git/tateyama/include/tateyama/api/server/response.h:18:10: fatal error: tateyama/proto/diagnostics.pb.h: No such file or directory
   18 | #include <tateyama/proto/diagnostics.pb.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```