### PR TITLE
protocol bufferの関数呼び出しに伴うビルド時警告の抑制

### DIFF
--- a/test/tateyama/endpoint/ipc/ipc_info_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_info_test.cpp
@@ -116,8 +116,8 @@ TEST_F(ipc_info_test, basic) {
     tateyama::proto::endpoint::request::Handshake hs{};
     hs.set_allocated_client_information(&cci);
     auto client = std::make_unique<ipc_client>(database_name, my_session_id, hs);
-    cci.release_credential();
-    hs.release_client_information();
+    (void)cci.release_credential();
+    (void)hs.release_client_information();
 
     client->send(service_id_of_info_service, std::string(request_test_message));  // we do not care service_id nor request message here
     std::string res{};

--- a/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
@@ -132,8 +132,8 @@ class ipc_lob_disallow_test : public ::testing::Test {
         tateyama::proto::endpoint::request::Handshake hs{};
         hs.set_allocated_client_information(&cci);
         client_ = std::make_unique<ipc_client>(database_name, my_session_id, hs);
-        cci.release_credential();
-        hs.release_client_information();
+        (void)cci.release_credential();
+        (void)hs.release_client_information();
     }
 
     void TearDown() override {

--- a/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
@@ -132,8 +132,8 @@ class ipc_lob_test : public ::testing::Test {
         tateyama::proto::endpoint::request::Handshake hs{};
         hs.set_allocated_client_information(&cci);
         client_ = std::make_unique<ipc_client>(database_name, my_session_id, hs);
-        cci.release_credential();
-        hs.release_client_information();
+        (void)cci.release_credential();
+        (void)hs.release_client_information();
     }
 
     void TearDown() override {

--- a/test/tateyama/endpoint/ipc/ipc_session_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_session_test.cpp
@@ -162,7 +162,7 @@ TEST_F(ipc_session_test, cancel_request_reply) {
     tateyama::proto::endpoint::request::Request endpoint_request{};
     endpoint_request.set_allocated_cancel(&cancel);
     client_->send(tateyama::framework::service_id_endpoint_broker, endpoint_request.SerializeAsString());
-    endpoint_request.release_cancel();
+    (void)endpoint_request.release_cancel();
 
     service_.wait_request_arrival();
     // server part (send cancel success by error)
@@ -191,7 +191,7 @@ TEST_F(ipc_session_test, cancel_request_noreply) {
     tateyama::proto::endpoint::request::Request endpoint_request{};
     endpoint_request.set_allocated_cancel(&cancel);
     client_->send(tateyama::framework::service_id_endpoint_broker, endpoint_request.SerializeAsString());
-    endpoint_request.release_cancel();
+    (void)endpoint_request.release_cancel();
 
     service_.wait_request_arrival();
     // server part (dispose response object)

--- a/test/tateyama/endpoint/stream/stream_client.cpp
+++ b/test/tateyama/endpoint/stream/stream_client.cpp
@@ -158,8 +158,8 @@ void stream_client::handshake() {
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;
     }
-    endpoint_request.release_handshake();
-    endpoint_handshake_.release_wire_information();
+    (void)endpoint_request.release_handshake();
+    (void)endpoint_handshake_.release_wire_information();
 
     try {
         receive(handshake_response_);

--- a/test/tateyama/endpoint/stream/stream_info_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_info_test.cpp
@@ -122,8 +122,8 @@ TEST_F(stream_info_test, basic) {
         hs.set_allocated_client_information(&cci);
         auto client = std::make_unique<stream_client>(hs);
         client->send(service_id_of_info_service, request_test_message);  // we do not care service_id nor request message here
-        cci.release_credential();
-        hs.release_client_information();
+        (void)cci.release_credential();
+        (void)hs.release_client_information();
 
         // client  part
         client->receive();

--- a/test/tateyama/endpoint/stream/stream_session_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_session_test.cpp
@@ -183,7 +183,7 @@ TEST_F(stream_session_test, cancel_request_reply) {
         tateyama::proto::endpoint::request::Request endpoint_request{};
         endpoint_request.set_allocated_cancel(&cancel);
         EXPECT_TRUE(client_->send(tateyama::framework::service_id_endpoint_broker, endpoint_request.SerializeAsString()));
-        endpoint_request.release_cancel();
+        (void)endpoint_request.release_cancel();
 
         service_.wait_request_arrival();
         // server part (send cancel success by error)
@@ -215,7 +215,7 @@ TEST_F(stream_session_test, cancel_request_noreply) {
         tateyama::proto::endpoint::request::Request endpoint_request{};
         endpoint_request.set_allocated_cancel(&cancel);
         EXPECT_TRUE(client_->send(tateyama::framework::service_id_endpoint_broker, endpoint_request.SerializeAsString()));
-        endpoint_request.release_cancel();
+        (void)endpoint_request.release_cancel();
 
         service_.wait_request_arrival();
         // server part (send cancel success by error)


### PR DESCRIPTION
tateyamaをubuntu 24.04環境でビルドすると下記のように警告がでるのですがあまり意味のないものだと思うので (void)にキャストすることで抑制したいと思います。

```
kuro@24.04:~/git/tateyama/build-debug-shirakami$ ninja
[8/201] Running cpp protocol buffer compiler on tateyama/proto/auth/request.proto
tateyama/proto/auth/request.proto:9:1: warning: Import tateyama/proto/auth/common.proto is unused.
[9/201] Running cpp protocol buffer compiler on tateyama/proto/auth/response.proto
tateyama/proto/auth/response.proto:9:1: warning: Import tateyama/proto/auth/common.proto is unused.
[117/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/stream/stream_client.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_client.cpp: In member function ‘void tateyama::api::endpoint::stream::stream_client::handshake()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_client.cpp:161:39: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Handshake* tateyama::proto::endpoint::request::Request::release_handshake()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  161 |     endpoint_request.release_handshake();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_client.h:33,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_client.cpp:20:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2033:57: note: declared here
 2033 | inline ::tateyama::proto::endpoint::request::Handshake* Request::release_handshake() {
      |                                                         ^~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_client.cpp:162:49: warning: ignoring return value of ‘tateyama::proto::endpoint::request::WireInformation* tateyama::proto::endpoint::request::Handshake::release_wire_information()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  162 |     endpoint_handshake_.release_wire_information();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2523:63: note: declared here
 2523 | inline ::tateyama::proto::endpoint::request::WireInformation* Handshake::release_wire_information() {
      |                                                               ^~~~~~~~~
[122/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp: In member function ‘virtual void tateyama::endpoint::ipc::ipc_lob_disallow_test::SetUp()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp:135:31: warning: ignoring return value of tateyama::proto::endpoint::request::Credential* tateyama::proto::endpoint::request::ClientInformation::release_credentia()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  135 |         cci.release_credential();
      |         ~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/ipc/bootstrap/ipc_worker.h:20,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp:17:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2717:58: note: declared here
 2717 | inline ::tateyama::proto::endpoint::request::Credential* ClientInformation::release_credential() {
      |                                                          ^~~~~~~~~~~~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp:136:38: warning: ignoring return value of tateyama::proto::endpoint::request::ClientInformation* tateyama::proto::endpoint::request::Handshake::release_client_information()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  136 |         hs.release_client_information();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2433:65: note: declared here
 2433 | inline ::tateyama::proto::endpoint::request::ClientInformation* Handshake::release_client_information() {
      |                                                                 ^~~~~~~~~
[124/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/ipc/ipc_session_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_session_test.cpp: In member function ‘virtual void tateyama::endpoint::ipc::ipc_session_test_cancel_request_reply_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_session_test.cpp:165:36: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Cancel* tateyama::proto::endpoint::request::Request::release_cancel()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  165 |     endpoint_request.release_cancel();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/ipc/bootstrap/ipc_worker.h:20,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_session_test.cpp:23:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2107:54: note: declared here
 2107 | inline ::tateyama::proto::endpoint::request::Cancel* Request::release_cancel() {
      |                                                      ^~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_session_test.cpp: In member function ‘virtual void tateyama::endpoint::ipc::ipc_session_test_cancel_request_noreply_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_session_test.cpp:194:36: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Cancel* tateyama::proto::endpoint::request::Request::release_cancel()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  194 |     endpoint_request.release_cancel();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2107:54: note: declared here
 2107 | inline ::tateyama::proto::endpoint::request::Cancel* Request::release_cancel() {
      |                                                      ^~~~~~~
[129/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/ipc/ipc_info_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_info_test.cpp: In member function ‘virtual void tateyama::endpoint::ipc::ipc_info_test_basic_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_info_test.cpp:119:27: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Credential* tateyama::proto::endpoint::request::ClientInformation::release_credential()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  119 |     cci.release_credential();
      |     ~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/ipc/bootstrap/ipc_worker.h:20,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_info_test.cpp:17:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2717:58: note: declared here
 2717 | inline ::tateyama::proto::endpoint::request::Credential* ClientInformation::release_credential() {
      |                                                          ^~~~~~~~~~~~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_info_test.cpp:120:34: warning: ignoring return value of ‘tateyama::proto::endpoint::request::ClientInformation* tateyama::proto::endpoint::request::Handshake::release_client_informatio()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  120 |     hs.release_client_information();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2433:65: note: declared here
 2433 | inline ::tateyama::proto::endpoint::request::ClientInformation* Handshake::release_client_information() {
      |                                                                 ^~~~~~~~~
[148/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/ipc/ipc_lob_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_test.cpp: In member function ‘virtual void tateyama::endpoint::ipc::ipc_lob_test::SetUp()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_test.cpp:135:31: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Credential* tateyama::proto::endpoint::request::ClientInformation::release_credential()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  135 |         cci.release_credential();
      |         ~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/ipc/bootstrap/ipc_worker.h:20,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_test.cpp:17:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2717:58: note: declared here
 2717 | inline ::tateyama::proto::endpoint::request::Credential* ClientInformation::release_credential() {
      |                                                          ^~~~~~~~~~~~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/ipc/ipc_lob_test.cpp:136:38: warning: ignoring return value of ‘tateyama::proto::endpoint::request::ClientInformation* tateyama::proto::endpoint::request::Handshake::release_client_information()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  136 |         hs.release_client_information();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2433:65: note: declared here
 2433 | inline ::tateyama::proto::endpoint::request::ClientInformation* Handshake::release_client_information() {
      |                                                                 ^~~~~~~~~
[151/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/stream/stream_info_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_info_test.cpp: In member function ‘virtual void tateyama::api::endpoint::stream::stream_info_test_basic_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_info_test.cpp:125:31: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Credential* tateyama::proto::endpoint::request::ClientInformation::release_credential()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  125 |         cci.release_credential();
      |         ~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/stream/bootstrap/stream_worker.h:21,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_info_test.cpp:19:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2717:58: note: declared here
 2717 | inline ::tateyama::proto::endpoint::request::Credential* ClientInformation::release_credential() {
      |                                                          ^~~~~~~~~~~~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_info_test.cpp:126:38: warning: ignoring return value of ‘tateyama::proto::endpoint::request::ClientInformation* tateyama::proto::endpoint::request::Handshake::release_client_information()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  126 |         hs.release_client_information();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2433:65: note: declared here
 2433 | inline ::tateyama::proto::endpoint::request::ClientInformation* Handshake::release_client_information() {
      |                                                                 ^~~~~~~~~
[152/201] Building CXX object test/CMakeFiles/tateyama-test.dir/tateyama/endpoint/stream/stream_session_test.cpp.o
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_session_test.cpp: In member function ‘virtual void tateyama::api::endpoint::stream::stream_session_test_cancel_request_reply_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_session_test.cpp:186:40: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Cancel* tateyama::proto::endpoint::request::Request::release_cancel()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  186 |         endpoint_request.release_cancel();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/kuro/git/tateyama/src/./tateyama/endpoint/common/worker_common.h:37,
                 from /home/kuro/git/tateyama/src/./tateyama/endpoint/stream/bootstrap/stream_worker.h:21,
                 from /home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_session_test.cpp:21:
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2107:54: note: declared here
 2107 | inline ::tateyama::proto::endpoint::request::Cancel* Request::release_cancel() {
      |                                                      ^~~~~~~
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_session_test.cpp: In member function ‘virtual void tateyama::api::endpoint::stream::stream_session_test_cancel_request_noreply_Test::TestBody()’:
/home/kuro/git/tateyama/test/tateyama/endpoint/stream/stream_session_test.cpp:218:40: warning: ignoring return value of ‘tateyama::proto::endpoint::request::Cancel* tateyama::proto::endpoint::request::Request::release_cancel()’, declared with attribute ‘nodiscard’ [-Wunused-result]
  218 |         endpoint_request.release_cancel();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/kuro/git/tateyama/build-debug-shirakami/src/tateyama/proto/endpoint/request.pb.h:2107:54: note: declared here
 2107 | inline ::tateyama::proto::endpoint::request::Cancel* Request::release_cancel() {
      |                                                      ^~~~~~~
[201/201] Linking CXX executable test/tateyama-test
```