### PR TITLE
implement system service

### DIFF
--- a/docs/internal/system-information_ja.md
+++ b/docs/internal/system-information_ja.md
@@ -1,0 +1,184 @@
+# システム情報取得機能に関するデザイン
+
+## この文書について
+* Tsubakuro経由でtsurugidbのシステム情報を取得する機能を設計する
+
+## 基本的な考え方
+  * TsubakuroにSystemClientを作る、これが system_information というメッセージをやりとりする
+  * tateyamaにsystem-serviceを作り、system_information メッセージをやりとりする
+  
+## 境界デザイン
+
+### メッセージ
+tateyama/proto/systemに下記メッセージを配置する。
+
+```proto
+message system.request.Request {
+    // service message version (major)
+    uint64 service_message_version_major = 1;
+
+    // service message version (minor)
+    uint64 service_message_version_minor = 2;
+
+    // reserved for system use
+    reserved 3 to 10;
+
+    // the request command.
+    oneof command {
+        // get system information.
+        GetSystemInfo getSystemInfo = 11;
+    }
+    reserved 12 to 99;
+}
+
+// request to get system information.
+message system.request.GetSystemInfo {
+    // no special properties.
+}
+
+
+// an error occurred.
+message system.response.Error {
+    // the error message.
+    string message = 1;
+
+    // error code
+    diagnostic.ErrorCode code = 2;
+
+    // supplemental text for debug purpose
+    string supplemental_text = 3;
+}
+
+// response of get system information request.
+message system.response.GetSystemInfo {
+    reserved 1 to 10;
+
+    // the response body.
+    oneof result {
+        // request is successfully completed.
+        Success success = 11;
+
+        // error occurred.
+        Error error = 12;
+    }
+
+    // request is successfully completed.
+    message Success {
+        // the system information.
+        SystemInfo system_info = 1;
+    }
+}
+
+// system information.
+message system.response.SystemInfo {
+
+    // name field of tsurugi-info.json
+    string name = 1;
+
+    // version field of tsurugi-info.json
+    string version = 2;
+
+    // date field of tsurugi-info.json
+    string date = 3;
+
+    // url field of tsurugi-info.json
+    string url = 4;
+}
+
+// the error code.
+enum system.diagnostic.ErrorCode {
+    // the error code is not set.
+    ERROR_CODE_NOT_SPECIFIED = 0;
+
+    // the unknown error occurred.
+    UNKNOWN = 1;
+
+    // the target is not found.
+    NOT_FOUND = 2;
+}
+```
+
+
+### クライアント
+com.tsurugidb.tsubakuro.systemに下記APIを配置する。
+
+```java
+/**
+ * A System client.
+ * @see #attach(Session)
+ */
+@ServiceMessageVersion(
+        service = SystemClient.SERVICE_SYMBOLIC_ID,
+        major = SystemClient.SERVICE_MESSAGE_VERSION_MAJOR,
+        minor = SystemClient.SERVICE_MESSAGE_VERSION_MINOR)
+public interface SystemClient extends ServerResource, ServiceClient {
+
+    /**
+     * The symbolic ID of the destination service.
+    */
+    String SERVICE_SYMBOLIC_ID = "system";
+
+    /**
+     * The major service message version which this client requests.
+     */
+    int SERVICE_MESSAGE_VERSION_MAJOR = 0;
+
+    /**
+     * The minor service message version which this client requests.
+     */
+    int SERVICE_MESSAGE_VERSION_MINOR = 1;
+
+    /**
+     * Attaches to the System service in the current session.
+     * @param session the current session
+     * @return the System service client
+     */
+    static SystemClient attach(@Nonnull Session session) {
+        Objects.requireNonNull(session);
+        return SystemClientImpl.attach(session);
+    }
+
+    /**
+     * Get the system information of the database to which the session is connected.
+     * @return a future of SystemResponse.SystemInfo message
+     * @throws IOException if I/O error occurred while sending request
+     */
+    default FutureResponse<SystemResponse.SystemInfo> getSystemInfo() throws IOException;
+}
+```
+
+また、`META-INF/tsurugidb/clients`に`SystemClient`を登録する。
+
+### サーバ
+#### system service
+tateyama/systemにsystem serviceを作る。component idは下記とする。
+```
+constexpr inline component::id_type service_id_system = 12;
+```
+
+memo: system serviceをtsurugidbに組み込む操作はtateyamaで行い、tateyamaの外部（tateyama-bootstrap等）は関与しない。また、システム情報の取得はtsurugidbの起動時に行う。このため、tsurugidbの動作中にtsurugi-info.json（次項）を書き換えても、それはgetSystemInfo()の結果に反映されない。
+
+#### システム情報の取得
+* システム情報は、下記フィールドを有するjsonファイル（ファイル名：`tsurugi-info.json`）から取得する。
+  
+| フィールド名 | 型    | 値 |
+|------------:| :---: |:--------------------|
+| name        | 文字列 | データベースの製品名 |
+| version     | 文字列 | 製品のバージョン     |
+| date        | 文字列 | 製品のビルド日時（ISO 8601形式）     |
+| uri         | 文字列 | バージョンに対応するgitリポジトリのURL<BR>起点は`https://github.com/project-tsurugi/tsurugidb` |
+
+  * `tsurugi-info.json`の内容例は下記。
+```
+{
+    "name": "tsurugidb",
+    "version": "1.8.0-SNAPSHOT-202512100915-18c8535",
+    "date": "2025-12-10T09:18Z",
+    "url": "//tree/18c853557bfb0a81e14f1181136b060891794cf4"
+}
+```
+memo: `Message SystemResponse.SystemInfo`は、`tsurugi-info.json`の現状に合わせ、name, version, date, urlの文字列を持つMessageとする。将来`tsurugi-info.json`のフィールドが追加された際は、それに応じて`Message SystemResponse.SystemInfo`のフィールドを追加しても良い。
+
+* システム情報を取得する`tsurugi-info.json`の位置は下記とする。
+  * 環境変数`TSURUGI_HOME`が設定されている場合は `${TSURUGI_HOME}/lib/tsurugi-info.json`とする。そのファイルが存在しない場合、getSystemInfoリクエストに対して`response.GetSystemInfo.error`の`code`に`diagnostic.ErrorCode.NOT_FOUND`を設定したメッセージを返す。
+  * 環境変数`TSURUGI_HOME`が設定されていない場合はtsurugidbの実行ファイル（`libexec/libexec/tsurugidb`）が置かれているディレクトリを起点とする相対パス `../lib/tsurugi-info.json` とする。そのファイルが存在しない場合、getSystemInfoリクエストに対して前項記載と同じエラーメッセージを返す。

--- a/include/tateyama/framework/component_ids.h
+++ b/include/tateyama/framework/component_ids.h
@@ -48,5 +48,6 @@ constexpr inline component::id_type service_id_altimeter = 9;
 #endif
 constexpr inline component::id_type service_id_request = 10;
 constexpr inline component::id_type service_id_authentication = 11;
+constexpr inline component::id_type service_id_system = 12;
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ file(GLOB SOURCES
         "tateyama/request/service/*.cpp"
         "tateyama/authentication/resource/*.cpp"
         "tateyama/authentication/service/*.cpp"
+        "tateyama/system/service/*.cpp"
 )
 if (ENABLE_ALTIMETER)
     file(GLOB ALTIMETER_SOURCES

--- a/src/tateyama/endpoint/common/request.h
+++ b/src/tateyama/endpoint/common/request.h
@@ -190,7 +190,7 @@ protected:
             }
             return;
         }
-        throw std::runtime_error("error in parse framework header");
+        throw std::runtime_error("error occurred while parsing a request message in Protocol Buffers");
     }
     
 private:

--- a/src/tateyama/framework/server.cpp
+++ b/src/tateyama/framework/server.cpp
@@ -43,6 +43,7 @@
 #include <tateyama/session/resource/bridge.h>
 #include <tateyama/metrics/service/bridge.h>
 #include <tateyama/metrics/resource/bridge.h>
+#include <tateyama/system/service/bridge.h>
 #ifdef ENABLE_ALTIMETER
 #include "altimeter_logger.h"
 #include <tateyama/altimeter/service/bridge.h>
@@ -210,6 +211,7 @@ void add_core_components(server& svr) {
 #endif
     svr.add_service(std::make_shared<tateyama::request::service::bridge>());
     svr.add_service(std::make_shared<tateyama::authentication::service::bridge>());
+    svr.add_service(std::make_shared<tateyama::system::service::system_service_bridge>());
 
     svr.add_endpoint(std::make_shared<framework::ipc_endpoint>());
     svr.add_endpoint(std::make_shared<framework::stream_endpoint>());

--- a/src/tateyama/proto/system/diagnostic.proto
+++ b/src/tateyama/proto/system/diagnostic.proto
@@ -11,7 +11,7 @@ enum ErrorCode {
     // the error code is not set.
     ERROR_CODE_NOT_SPECIFIED = 0;
 
-    // the unknown error was occurred.
+    // the unknown error occurred.
     UNKNOWN = 1;
 
     // the target is not found.

--- a/src/tateyama/proto/system/diagnostic.proto
+++ b/src/tateyama/proto/system/diagnostic.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package tateyama.proto.system.diagnostic;
+
+option java_multiple_files = false;
+option java_package = "com.tsurugidb.system.proto";
+option java_outer_classname = "SystemDiagnostic";
+
+// the error code.
+enum ErrorCode {
+    // the error code is not set.
+    ERROR_CODE_NOT_SPECIFIED = 0;
+
+    // the unknown error was occurred.
+    UNKNOWN = 1;
+
+    // the target is not found.
+    NOT_FOUND = 2;
+}

--- a/src/tateyama/proto/system/request.proto
+++ b/src/tateyama/proto/system/request.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package tateyama.proto.system.request;
+
+option java_multiple_files = false;
+option java_package = "com.tsurugidb.system.proto";
+option java_outer_classname = "SystemRequest";
+
+// the request message to system pseudo service.
+message Request {
+    // service message version (major)
+    uint64 service_message_version_major = 1;
+
+    // service message version (minor)
+    uint64 service_message_version_minor = 2;
+
+    // reserved for system use
+    reserved 3 to 10;
+
+    // the request command.
+    oneof command {
+        // get system information.
+        GetSystemInfo getSystemInfo = 11;
+    }
+    reserved 12 to 99;
+}
+
+// request to get system information.
+message GetSystemInfo {
+    // no special properties.
+}

--- a/src/tateyama/proto/system/response.proto
+++ b/src/tateyama/proto/system/response.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package tateyama.proto.system.response;
+
+option java_multiple_files = false;
+option java_package = "com.tsurugidb.system.proto";
+option java_outer_classname = "SystemResponse";
+
+import "tateyama/proto/system/diagnostic.proto";
+
+message Error {
+    // the error message.
+    string message = 1;
+
+    // error code
+    diagnostic.ErrorCode code = 2;
+
+    // supplemental text for debug purpose
+    string supplemental_text = 4;
+}
+
+// response of get system information request.
+message GetSystemInfo {
+    reserved 1 to 10;
+
+    // the response body.
+    oneof result {
+        // request is successfully completed.
+        Success success = 11;
+
+        // error occurred.
+        Error error = 12;
+    }
+
+    // request is successfully completed.
+    message Success {
+        // the data channel name of retrieved large object data.
+        SystemInfo system_info = 1;
+    }
+}
+
+// system information.
+message SystemInfo {
+
+    // name field of tsurugi-info.json
+    string name = 1;
+
+    // version field of tsurugi-info.json
+    string version = 2;
+
+    // date field of tsurugi-info.json
+    string date = 3;
+
+    // url field of tsurugi-info.json
+    string url = 4;
+}

--- a/src/tateyama/proto/system/response.proto
+++ b/src/tateyama/proto/system/response.proto
@@ -16,7 +16,7 @@ message Error {
     diagnostic.ErrorCode code = 2;
 
     // supplemental text for debug purpose
-    string supplemental_text = 4;
+    string supplemental_text = 3;
 }
 
 // response of get system information request.

--- a/src/tateyama/system/service/bridge.cpp
+++ b/src/tateyama/system/service/bridge.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bridge.h"
+
+namespace tateyama::system::service {
+
+using tateyama::api::server::request;
+using tateyama::api::server::response;
+
+using namespace framework;
+
+component::id_type system_service_bridge::id() const noexcept {
+    return tag;
+}
+
+bool system_service_bridge::setup(environment&) {
+    core_ = std::make_unique<system_service_core>();
+    try {
+        LOG_LP(INFO) << "tsurugidb system info is '" << core_->info_handler_.to_string() << '\'';
+    } catch (const std::runtime_error &ex) {
+        LOG_LP(INFO) << ex.what();
+    }
+    return core_ != nullptr;
+}
+
+bool system_service_bridge::start(environment&) {
+    return true;
+}
+
+bool system_service_bridge::shutdown(environment&) {
+    return true;
+}
+
+bool system_service_bridge::operator()(std::shared_ptr<request> req, std::shared_ptr<response> res) {
+    return core_->operator()(req, res);
+}
+
+std::string_view system_service_bridge::label() const noexcept {
+    return component_label;
+}
+
+system_service_bridge::~system_service_bridge() = default;
+
+} // namespace

--- a/src/tateyama/system/service/bridge.h
+++ b/src/tateyama/system/service/bridge.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include <tateyama/framework/service.h>
+#include <tateyama/framework/repository.h>
+#include <tateyama/api/server/request.h>
+#include <tateyama/api/server/response.h>
+#include <tateyama/framework/environment.h>
+#include <tateyama/framework/component_ids.h>
+#include <tateyama/system/service/core.h>
+
+namespace tateyama::system::service {
+
+using tateyama::api::server::request;
+using tateyama::api::server::response;
+
+/**
+ * @brief system service bridge for tateyama framework
+ * @details This object bridges system as a service component in tateyama framework.
+ * This object should be responsible only for life-cycle management.
+ */
+class system_service_bridge : public framework::service {
+public:
+    static constexpr id_type tag = framework::service_id_system;
+
+    [[nodiscard]] id_type id() const noexcept override;
+
+    //@brief human readable label of this component
+    static constexpr std::string_view component_label = "system_service";
+
+    /**
+     * @brief setup the component (the state will be `ready`)
+     */
+    bool setup(framework::environment&) override;
+
+    /**
+     * @brief start the component (the state will be `activated`)
+     */
+    bool start(framework::environment&) override;
+
+    /**
+     * @brief shutdown the component (the state will be `deactivated`)
+     */
+    bool shutdown(framework::environment&) override;
+
+    bool operator()(
+        std::shared_ptr<request> req,
+        std::shared_ptr<response> res) override;
+
+    /**
+     * @brief create empty object
+     */
+    system_service_bridge() = default;
+
+    system_service_bridge(system_service_bridge const& other) = delete;
+    system_service_bridge& operator=(system_service_bridge const& other) = delete;
+    system_service_bridge(system_service_bridge&& other) noexcept = delete;
+    system_service_bridge& operator=(system_service_bridge&& other) noexcept = delete;
+
+    /**
+     * @brief destructor the object
+     */
+    ~system_service_bridge() override;
+
+    /**
+     * @see `tateyama::framework::component::label()`
+     */
+    [[nodiscard]] std::string_view label() const noexcept override;
+private:
+    std::unique_ptr<tateyama::system::service::system_service_core> core_{};
+    bool deactivated_{false};
+};
+
+}

--- a/src/tateyama/system/service/core.cpp
+++ b/src/tateyama/system/service/core.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <thread>
+
+#include <tateyama/system/service/core.h>
+
+#include <tateyama/api/configuration.h>
+#include <tateyama/framework/component_ids.h>
+#include <tateyama/framework/service.h>
+
+#include <tateyama/proto/system/request.pb.h>
+#include <tateyama/proto/system/response.pb.h>
+#include <tateyama/proto/system/diagnostic.pb.h>
+
+namespace tateyama::system::service {
+
+using tateyama::api::server::request;
+using tateyama::api::server::response;
+
+/**
+ * @brief Handles a system service request.
+ *
+ * This function processes the incoming request and populates the response accordingly.
+ *
+ * @param req The incoming request object.
+ * @param res The response object to populate.
+ * @return true if the request was handled successfully; false otherwise.
+ *
+ * @note
+ * Any exceptions of type std::runtime_error thrown when a permission error occurs
+ * during request processing are caught internally. In such cases, an error response
+ * is set in @p res, and the function returns false. Callers should not expect
+ * std::runtime_error exceptions to propagate from this function.
+ */
+bool system_service_core::operator()(const std::shared_ptr<request>& req, const std::shared_ptr<response>& res) {
+    try {
+        tateyama::proto::system::request::Request rq{};
+
+        auto data = req->payload();
+        if(!rq.ParseFromArray(data.data(), static_cast<int>(data.size()))) {
+            LOG_LP(ERROR) << "request parse error";
+            return false;
+        }
+
+        if (rq.service_message_version_major() > 0 ||
+            (rq.service_message_version_major() == 0 && rq.service_message_version_minor() > 0)) {
+            tateyama::proto::diagnostics::Record error{};
+            error.set_code(tateyama::proto::diagnostics::Code::INVALID_REQUEST);
+            error.set_message("unsupported message version");
+            res->error(error);
+            return false;
+        }
+
+        auto session_id = req->session_id();
+        res->session_id(session_id);
+        switch(rq.command_case()) {
+        case tateyama::proto::system::request::Request::kGetSystemInfo:
+        {
+            tateyama::proto::system::response::GetSystemInfo rs{};
+            if (!info_handler_.error()) {
+                info_handler_.set_system_info(rs.mutable_success()->mutable_system_info());
+                res->body(rs.SerializeAsString());
+                return true;
+            }
+            auto* error = rs.mutable_error();
+            error->set_code(tateyama::proto::system::diagnostic::ErrorCode::NOT_FOUND);
+            error->set_message("cannot find system information");
+            res->body(rs.SerializeAsString());
+            return true;
+        }
+
+        default:
+            return false;
+        }
+
+    } catch (const std::runtime_error &ex) {
+        tateyama::proto::diagnostics::Record error{};
+        error.set_code(tateyama::proto::diagnostics::Code::UNKNOWN);
+        error.set_message(ex.what());
+        res->error(error);
+        return false;
+    }
+}
+
+system_service_core::system_service_core() = default;
+
+}

--- a/src/tateyama/system/service/core.h
+++ b/src/tateyama/system/service/core.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <tateyama/api/configuration.h>
+#include <tateyama/framework/component_ids.h>
+#include <tateyama/framework/service.h>
+
+#include "info_handler.h"
+
+namespace tateyama::system::service {
+
+using tateyama::api::server::request;
+using tateyama::api::server::response;
+
+/**
+ * @brief system service main object
+ */
+class system_service_core {
+public:
+    system_service_core();
+
+    bool operator()(
+        const std::shared_ptr<request>& req,
+        const std::shared_ptr<response>& res
+    );
+
+private:
+    info_handler info_handler_{};
+
+    friend class system_service_bridge;
+};
+
+}

--- a/src/tateyama/system/service/info_handler.h
+++ b/src/tateyama/system/service/info_handler.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <exception>
+#include <stdlib.h>
+
+#include <nlohmann/json.hpp>
+
+#include <tateyama/proto/system/response.pb.h>
+
+namespace tateyama::system::service {
+
+/**
+ * @brief tsurugi-info.json handler
+ */
+class info_handler {
+public:
+    info_handler() {
+        parse_info(info_file_path());
+    }
+
+    bool error() {
+        return error_;
+    }
+    void set_system_info(tateyama::proto::system::response::SystemInfo* system_info) {
+        system_info->set_name(name_);
+        system_info->set_version(version_);
+        system_info->set_date(date_);
+        system_info->set_url(url_);
+    }
+    std::string to_string() {
+        std::stringstream ss{};
+        ss << "name = " << name_;
+        ss << ", version = " << version_;
+        ss << ", date = " << date_;
+        ss << ", url = " << url_;
+        return ss.str();
+    }
+
+private:
+    std::string name_{};
+    std::string version_{};
+    std::string date_{};
+    std::string url_{};
+    bool error_{};
+    const std::filesystem::path info_path = std::filesystem::path("lib/tsurugi-info.json");
+
+    std::filesystem::path info_file_path() {
+        auto env_tsurugi_home = getenv("TSURUGI_HOME");
+        if (env_tsurugi_home) {
+            std::filesystem::path tsurugi_home(env_tsurugi_home);
+            return tsurugi_home / info_path;
+        }
+        return std::filesystem::canonical("/proc/self/exe").parent_path().parent_path() / info_path;
+    }
+
+    void parse_info(const std::filesystem::path& path) {
+        if (std::filesystem::exists(path)) {
+            try {
+                std::ifstream stream{path};
+                nlohmann::json j = nlohmann::json::parse(stream);
+
+                if (j.find("name") != j.end()) {
+                    name_ = j["name"];
+                }
+                if (j.find("version") != j.end()) {
+                    version_ = j["version"];
+                }
+                if (j.find("date") != j.end()) {
+                    date_ = j["date"];
+                }
+                if (j.find("url") != j.end()) {
+                    url_ = j["url"];
+                }
+            } catch (const std::exception &ex) {
+                error_ = true;
+            }
+        } else {
+            error_ = true;
+        }
+    }
+};
+
+}

--- a/src/tateyama/system/service/info_handler.h
+++ b/src/tateyama/system/service/info_handler.h
@@ -37,7 +37,7 @@ public:
         parse_info(info_file_path());
     }
 
-    bool error() {
+    [[nodiscard]] bool error() const {
         return error_;
     }
     void set_system_info(tateyama::proto::system::response::SystemInfo* system_info) {
@@ -46,7 +46,7 @@ public:
         system_info->set_date(date_);
         system_info->set_url(url_);
     }
-    std::string to_string() {
+    [[nodiscard]] std::string to_string() {
         std::stringstream ss{};
         ss << "name = " << name_;
         ss << ", version = " << version_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ file(GLOB SRCS
         "tateyama/metrics/resource/*.cpp"
         "tateyama/request/service/*.cpp"
         "tateyama/authentication/resource/*.cpp"
+        "tateyama/system/*.cpp"
         )
 if (ENABLE_ALTIMETER)
     file(GLOB ALTIMETER_SOURCES

--- a/test/tateyama/endpoint/ipc/connection_queue_test.cpp
+++ b/test/tateyama/endpoint/ipc/connection_queue_test.cpp
@@ -78,7 +78,7 @@ class connection_queue_test : public ::testing::Test {
     };
 
     void SetUp() override {
-        rv_ = system("if [ -f /dev/shm/connection_queue_test ]; then rm -f /dev/shm/connection_queue_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/connection_queue_test ]; then rm -f /dev/shm/connection_queue_test; fi");
         container_ = std::make_unique < tateyama::endpoint::ipc::bootstrap::connection_container > (database_name, threads, admin_sessions);
         listener_ = std::make_unique < listener > (*container_);
         listener_thread_ = std::thread(std::ref(*listener_));
@@ -87,7 +87,7 @@ class connection_queue_test : public ::testing::Test {
     void TearDown() override {
         container_->get_connection_queue().request_terminate();
         listener_thread_.join();
-        rv_ = system("if [ -f /dev/shm/connection_queue_test ]; then rm -f /dev/shm/connection_queue_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/connection_queue_test ]; then rm -f /dev/shm/connection_queue_test; fi");
     }
 
     int rv_;

--- a/test/tateyama/endpoint/ipc/ipc_info_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_info_test.cpp
@@ -75,11 +75,11 @@ private:
 
 class ipc_info_test : public ::testing::Test {
     void SetUp() override {
-        rv_ = system("if [ -f /dev/shm/ipc_info_test ]; then rm -f /dev/shm/ipc_info_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_info_test ]; then rm -f /dev/shm/ipc_info_test; fi");
     }
 
     void TearDown() override {
-        rv_ = system("if [ -f /dev/shm/ipc_info_test ]; then rm -f /dev/shm/ipc_info_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_info_test ]; then rm -f /dev/shm/ipc_info_test; fi");
     }
 
     int rv_;

--- a/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
@@ -110,7 +110,7 @@ private:
 
 class ipc_lob_disallow_test : public ::testing::Test {
     void SetUp() override {
-        auto rv = system("if [ -f /dev/shm/ipc_lob_disallow_test ]; then rm -f /dev/shm/ipc_lob_disallow_test; fi");
+        auto rv = ::system("if [ -f /dev/shm/ipc_lob_disallow_test ]; then rm -f /dev/shm/ipc_lob_disallow_test; fi");
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
         // server part
@@ -140,7 +140,7 @@ class ipc_lob_disallow_test : public ::testing::Test {
         worker_->terminate(tateyama::session::shutdown_request_type::forceful);
         tateyama::server::ipc_listener_for_disallow_test::wait(*worker_);
 
-        auto rv = system("if [ -f /dev/shm/ipc_lob_disallow_test ]; then rm -f /dev/shm/ipc_lob_disallow_test; fi");
+        auto rv = ::system("if [ -f /dev/shm/ipc_lob_disallow_test ]; then rm -f /dev/shm/ipc_lob_disallow_test; fi");
     }
 
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};

--- a/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
@@ -110,7 +110,7 @@ private:
 
 class ipc_lob_test : public ::testing::Test {
     void SetUp() override {
-        auto rv = system("if [ -f /dev/shm/ipc_lob_test ]; then rm -f /dev/shm/ipc_lob_test; fi");
+        auto rv = ::system("if [ -f /dev/shm/ipc_lob_test ]; then rm -f /dev/shm/ipc_lob_test; fi");
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
         // server part
@@ -140,7 +140,7 @@ class ipc_lob_test : public ::testing::Test {
         worker_->terminate(tateyama::session::shutdown_request_type::forceful);
         tateyama::server::ipc_listener_for_test::wait(*worker_);
 
-        auto rv = system("if [ -f /dev/shm/ipc_lob_test ]; then rm -f /dev/shm/ipc_lob_test; fi");
+        auto rv = ::system("if [ -f /dev/shm/ipc_lob_test ]; then rm -f /dev/shm/ipc_lob_test; fi");
     }
 
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};

--- a/test/tateyama/endpoint/ipc/ipc_session_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_session_test.cpp
@@ -134,7 +134,7 @@ class ipc_session_test : public ::testing::Test {
     static constexpr std::size_t writer_count = 8;
 
     void SetUp() override {
-        rv_ = system("if [ -f /dev/shm/ipc_session_test ]; then rm -f /dev/shm/ipc_session_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_session_test ]; then rm -f /dev/shm/ipc_session_test; fi");
 
         // server part
         std::string session_name{database_name};
@@ -152,7 +152,7 @@ class ipc_session_test : public ::testing::Test {
     void TearDown() override {
         tateyama::server::ipc_listener_for_session_test::wait(*worker_);
 
-        rv_ = system("if [ -f /dev/shm/ipc_session_test ]; then rm -f /dev/shm/ipc_session_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_session_test ]; then rm -f /dev/shm/ipc_session_test; fi");
     }
 
     int rv_;

--- a/test/tateyama/endpoint/ipc/ipc_store_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_store_test.cpp
@@ -82,7 +82,7 @@ class ipc_store_test : public ::testing::Test {
     static constexpr std::size_t writer_count = 8;
 
     void SetUp() override {
-        rv_ = system("if [ -f /dev/shm/ipc_store_test ]; then rm -f /dev/shm/ipc_store_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_store_test ]; then rm -f /dev/shm/ipc_store_test; fi");
         // server part
         std::string session_name{database_name};
         session_name += "-";
@@ -98,7 +98,7 @@ class ipc_store_test : public ::testing::Test {
 
     void TearDown() override {
         tateyama::server::ipc_listener_for_store_test::wait(*worker_);
-        rv_ = system("if [ -f /dev/shm/ipc_store_test ]; then rm -f /dev/shm/ipc_store_test; fi");
+        rv_ = ::system("if [ -f /dev/shm/ipc_store_test ]; then rm -f /dev/shm/ipc_store_test; fi");
     }
 
     int rv_;

--- a/test/tateyama/system/system_info_test.cpp
+++ b/test/tateyama/system/system_info_test.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <memory>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <cstdlib>
+
+#include <tateyama/framework/server.h>
+#include <tateyama/framework/component_ids.h>
+
+#include <tateyama/proto/system/request.pb.h>
+#include <tateyama/proto/system/response.pb.h>
+#include <tateyama/system/service/bridge.h>
+
+#include <gtest/gtest.h>
+#include <tateyama/test_utils/utility.h>
+
+namespace tateyama::system {
+
+static constexpr std::size_t SERVICE_MESSAGE_VERSION_MAJOR = 0;
+static constexpr std::size_t SERVICE_MESSAGE_VERSION_MINOR = 0;
+
+class system_info_test :
+    public ::testing::Test,
+    public test_utils::utility
+{
+public:
+    void SetUp() override {
+        temporary_.prepare();
+        setenv("TSURUGI_HOME", path().c_str(), 1); // overwrite env
+
+        proto::system::request::Request request{};
+        request.set_service_message_version_major(SERVICE_MESSAGE_VERSION_MAJOR);
+        request.set_service_message_version_minor(SERVICE_MESSAGE_VERSION_MINOR);
+        (void) request.mutable_getsysteminfo();
+        auto str = request.SerializeAsString();
+        service_request_ = std::make_shared<test_utils::test_request>(10, system::service::system_service_bridge::tag, str);
+        service_response_ = std::make_shared<test_utils::test_response>();
+    }
+
+    void Start() {
+        auto cfg = api::configuration::create_configuration("", test_utils::default_configuration_for_tests);
+        set_dbpath(*cfg);
+        sv_ = std::make_unique<framework::server>(framework::boot_mode::database_server, cfg);
+        system_service_bridge_ = std::make_shared<system::service::system_service_bridge>();
+        sv_->add_service(system_service_bridge_);
+        ASSERT_TRUE(sv_->setup());
+        ASSERT_TRUE(sv_->start());
+    }
+    void TearDown() override {
+        ASSERT_TRUE(sv_->shutdown());
+    }
+
+protected:
+    std::shared_ptr<system::service::system_service_bridge> system_service_bridge_{};
+    std::shared_ptr<test_utils::test_request> service_request_{};
+    std::shared_ptr<test_utils::test_response> service_response_{};
+
+    void set_up_info() {
+        auto dir = std::filesystem::path(path()) / std::filesystem::path("lib");
+        std::filesystem::create_directory(dir);
+
+        std::ofstream strm(dir / std::filesystem::path("tsurugi-info.json"));
+        if (!strm) {
+            FAIL();
+        }
+        strm << R"({
+    "name": "tsurugidb",
+    "version": "1.1.1-SNAPSHOT",
+    "date": "2020-01-01T00:00Z",
+    "url": "//tree/0123456789abcdef0123456789abcdef01234567"
+}
+)";
+        strm.close();
+    }
+
+private:
+    std::unique_ptr<framework::server> sv_{};
+};
+
+TEST_F(system_info_test, success) {
+    set_up_info();
+    Start();
+    (*system_service_bridge_)(service_request_, service_response_);
+
+    auto& payload = service_response_->wait_and_get_body();
+    ASSERT_FALSE(service_response_->is_error());
+
+    proto::system::response::GetSystemInfo response{};
+    ASSERT_TRUE(response.ParseFromString(payload));
+    ASSERT_EQ(response.result_case(), proto::system::response::GetSystemInfo::kSuccess);
+    auto system_info = response.success().system_info();
+    EXPECT_EQ(system_info.name(), "tsurugidb");
+    EXPECT_EQ(system_info.version(), "1.1.1-SNAPSHOT");
+    EXPECT_EQ(system_info.date(), "2020-01-01T00:00Z");
+    EXPECT_EQ(system_info.url(), "//tree/0123456789abcdef0123456789abcdef01234567");
+}
+
+TEST_F(system_info_test, not_found) {
+    Start();
+    (*system_service_bridge_)(service_request_, service_response_);
+
+    auto& payload = service_response_->wait_and_get_body();
+    ASSERT_FALSE(service_response_->is_error());
+
+    proto::system::response::GetSystemInfo response{};
+    ASSERT_TRUE(response.ParseFromString(payload));
+    ASSERT_EQ(response.result_case(), proto::system::response::GetSystemInfo::kError);
+    EXPECT_EQ(response.error().code(), proto::system::diagnostic::ErrorCode::NOT_FOUND);
+}
+
+TEST_F(system_info_test, message_version_major) {
+    proto::system::request::Request request{};
+    request.set_service_message_version_major(SERVICE_MESSAGE_VERSION_MAJOR + 1);
+    request.set_service_message_version_minor(SERVICE_MESSAGE_VERSION_MINOR);
+    (void) request.mutable_getsysteminfo();
+    auto service_request = std::make_shared<test_utils::test_request>(10, system::service::system_service_bridge::tag, request.SerializeAsString());
+
+    Start();
+    (*system_service_bridge_)(service_request, service_response_);
+    ASSERT_TRUE(service_response_->wait_and_get_body().empty());
+    ASSERT_TRUE(service_response_->is_error());
+
+    auto& payload = service_response_->get_error();
+    proto::diagnostics::Record record{};
+    ASSERT_TRUE(record.ParseFromString(payload));
+    ASSERT_EQ(record.code(), proto::diagnostics::Code::INVALID_REQUEST);
+}
+
+TEST_F(system_info_test, message_version_minor) {
+    proto::system::request::Request request{};
+    request.set_service_message_version_major(SERVICE_MESSAGE_VERSION_MAJOR);
+    request.set_service_message_version_minor(SERVICE_MESSAGE_VERSION_MINOR + 1);
+    (void) request.mutable_getsysteminfo();
+    auto service_request = std::make_shared<test_utils::test_request>(10, system::service::system_service_bridge::tag, request.SerializeAsString());
+
+    Start();
+    (*system_service_bridge_)(service_request, service_response_);
+    ASSERT_TRUE(service_response_->wait_and_get_body().empty());
+    ASSERT_TRUE(service_response_->is_error());
+
+    auto& payload = service_response_->get_error();
+    proto::diagnostics::Record record{};
+    ASSERT_TRUE(record.ParseFromString(payload));
+    ASSERT_EQ(record.code(), proto::diagnostics::Code::INVALID_REQUEST);
+}
+
+} // namespace tateyama::system

--- a/test/tateyama/test_utils/test_server.h
+++ b/test/tateyama/test_utils/test_server.h
@@ -23,6 +23,7 @@
 #include <tateyama/session/resource/bridge.h>
 #include <tateyama/metrics/service/bridge.h>
 #include <tateyama/metrics/resource/bridge.h>
+#include <tateyama/system/service/bridge.h>
 #ifdef ENABLE_ALTIMETER
 #include <tateyama/altimeter/service/bridge.h>
 #endif
@@ -51,6 +52,7 @@ namespace tateyama::test_utils {
 #endif
         svr.add_service(std::make_shared<tateyama::request::service::bridge>());
         svr.add_service(std::make_shared<tateyama::authentication::service::bridge>());
+        svr.add_service(std::make_shared<tateyama::system::service::system_service_bridge>());
 
         svr.add_endpoint(std::make_shared<tateyama::framework::ipc_endpoint>());
     }
@@ -71,6 +73,7 @@ namespace tateyama::test_utils {
 #endif
         svr.add_service(std::make_shared<tateyama::request::service::bridge>());
         svr.add_service(std::make_shared<tateyama::authentication::service::bridge>());
+        svr.add_service(std::make_shared<tateyama::system::service::system_service_bridge>());
 
         svr.add_endpoint(std::make_shared<tateyama::framework::ipc_endpoint>());
     }

--- a/test/tateyama/test_utils/utility.h
+++ b/test/tateyama/test_utils/utility.h
@@ -37,8 +37,8 @@ public:
 
         auto* ipccfg = cfg.get_section("ipc_endpoint");
         BOOST_ASSERT(ipccfg != nullptr); //NOLINT
-        auto p = boost::filesystem::unique_path();
-        ipccfg->set("database_name", p.string());
+        database_name_ = boost::filesystem::unique_path().string();
+        ipccfg->set("database_name", database_name_);
 
         auto* stmcfg = cfg.get_section("stream_endpoint");
         BOOST_ASSERT(stmcfg != nullptr); //NOLINT
@@ -52,6 +52,7 @@ public:
 
 protected:
     temporary_folder temporary_{};
+    std::string database_name_{};
 };
 
 static constexpr std::string_view default_configuration_for_tests {  // NOLINT


### PR DESCRIPTION
This PR implements a new system service for the Tateyama framework that provides database product version information retrieval. The service follows the existing architectural patterns used by other services in the codebase (authentication, metrics, etc.) and integrates seamlessly with the framework's component lifecycle management.

# Key Changes
* Implements a new system service (system_service_bridge) with version retrieval functionality from tsurugi-info.json