### PR TITLE
change directory name for include of data-relay-grpc repository from …

### DIFF
--- a/include/tateyama/grpc/blob_relay_service_resource.h
+++ b/include/tateyama/grpc/blob_relay_service_resource.h
@@ -23,7 +23,7 @@
 #include <tateyama/framework/component_ids.h>
 #include <tateyama/framework/environment.h>
 
-#include <data-relay-grpc/blob_relay/service.h>
+#include <data_relay_grpc/blob_relay/service.h>
 
 namespace tateyama::grpc {
 

--- a/src/tateyama/grpc/blob_relay/blob_relay_service.h
+++ b/src/tateyama/grpc/blob_relay/blob_relay_service.h
@@ -27,7 +27,7 @@
 #include <tateyama/framework/environment.h>
 #include <tateyama/grpc/server/service_handler.h>
 
-#include <data-relay-grpc/blob_relay/service.h>
+#include <data_relay_grpc/blob_relay/service.h>
 
 namespace tateyama::grpc::blob_relay {
 


### PR DESCRIPTION
背景は下記
https://github.com/project-tsurugi/data-relay-grpc/pull/11#issue-3741007996

https://github.com/project-tsurugi/data-relay-grpc/pull/11
がmasterにマージされるとbuildエラーは解消される。