### PR TITLE
Feat instance

### DIFF
--- a/include/tateyama/api/server/database_info.h
+++ b/include/tateyama/api/server/database_info.h
@@ -66,6 +66,12 @@ public:
      * @returns the database started time
      */
     [[nodiscard]] virtual time_type start_at() const noexcept = 0;
+
+    /**
+     * @brief returns the instance_id of the database.
+     * @returns the instance_id
+     */
+    [[nodiscard]] virtual std::string_view instance_id() const noexcept = 0;
 };
 
 }

--- a/include/tateyama/configuration/configuration_provider.h
+++ b/include/tateyama/configuration/configuration_provider.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <tateyama/framework/resource.h>
+#include <tateyama/framework/component_ids.h>
+#include <tateyama/framework/environment.h>
+
+#include <tateyama/api/server/database_info.h>
+
+namespace tateyama::configuration {
+
+class configuration_provider : public ::tateyama::framework::resource {
+public:
+    /// @brief resource ID of this component.
+    static constexpr id_type tag = tateyama::framework::resource_id_configuration;
+
+    /// @brief human readable label of this component.
+    static constexpr std::string_view component_label = "configuration";
+
+    /**
+     * @brief provides configuration of the database.
+     * @return database information
+     */
+    [[nodiscard]] virtual api::server::database_info const& database_info() const noexcept = 0;
+};
+
+}

--- a/include/tateyama/framework/component_ids.h
+++ b/include/tateyama/framework/component_ids.h
@@ -32,6 +32,7 @@ constexpr inline component::id_type resource_id_remote_kvs = 8;
 constexpr inline component::id_type resource_id_metrics = 9;
 constexpr inline component::id_type resource_id_authentication = 10;
 constexpr inline component::id_type resource_id_blob_relay_service = 11;
+constexpr inline component::id_type resource_id_configuration = 13;
 
 // service
 constexpr inline component::id_type service_id_routing = 0;

--- a/include/tateyama/status/resource/bridge.h
+++ b/include/tateyama/status/resource/bridge.h
@@ -28,7 +28,7 @@
 #include <tateyama/framework/resource.h>
 #include <tateyama/framework/environment.h>
 
-#include <tateyama/api/server/database_info.h>
+#include <tateyama/configuration/configuration_provider.h>
 
 namespace tateyama::status_info::resource {
 
@@ -143,14 +143,6 @@ public:
     [[nodiscard]] std::string_view label() const noexcept override;
 
     /**
-     * @brief returns a reference to the database_info
-     * @return database info
-     */
-    [[nodiscard]] const tateyama::api::server::database_info& database_info() const noexcept {
-        return *database_info_;
-    }
-
-    /**
      * @brief returns the database name
      * @return database name
      */
@@ -163,7 +155,7 @@ private:
     std::unique_ptr<boost::interprocess::managed_shared_memory> segment_;
     std::unique_ptr<resource_status_memory> resource_status_memory_{};
     std::string digest_{};
-    std::unique_ptr<tateyama::api::server::database_info> database_info_{};
+    std::shared_ptr<tateyama::configuration::configuration_provider> configuration_{};
 
     void set_digest(const std::string& path_string);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ file(GLOB SOURCES
         "tateyama/authentication/resource/*.cpp"
         "tateyama/authentication/service/*.cpp"
         "tateyama/system/service/*.cpp"
+        "tateyama/configuration/resource/*.cpp"
 )
 if (ENABLE_ALTIMETER)
     file(GLOB ALTIMETER_SOURCES

--- a/src/tateyama/configuration/resource/configuration_provider_impl.cpp
+++ b/src/tateyama/configuration/resource/configuration_provider_impl.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "configuration_provider_impl.h"
+
+namespace tateyama::configuration::resource {
+
+api::server::database_info const& configuration_provider_impl::database_info() const noexcept {
+    return status_->database_info();
+}
+
+bool configuration_provider_impl::setup(framework::environment& env) {
+    status_ = env.resource_repository().find<status_info::resource::bridge>();
+    return status_ != nullptr;
+}
+
+bool configuration_provider_impl::start(framework::environment&) {
+    return true;
+}
+
+bool configuration_provider_impl::shutdown(framework::environment&) {
+    return true;
+}
+
+tateyama::framework::component::id_type configuration_provider_impl::id() const noexcept {
+    return tag;
+}
+
+std::string_view configuration_provider_impl::label() const noexcept {
+    return component_label;
+}
+
+}

--- a/src/tateyama/configuration/resource/configuration_provider_impl.cpp
+++ b/src/tateyama/configuration/resource/configuration_provider_impl.cpp
@@ -37,7 +37,7 @@ bool configuration_provider_impl::setup(framework::environment& env) {
     auto* system_section = conf->get_section("system");
     auto instance_id_opt = system_section->get<std::string>("instance_id");
     if (!instance_id_opt) {
-        LOG(ERROR) << "cannot find  instance_id at the system section in the configuration";
+        LOG(ERROR) << "cannot find instance_id at the system section in the configuration";
         return false;
     }
 

--- a/src/tateyama/configuration/resource/configuration_provider_impl.h
+++ b/src/tateyama/configuration/resource/configuration_provider_impl.h
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include "tateyama/status/resource/bridge.h"
-
 #include <tateyama/configuration/configuration_provider.h>
+#include "database_info_impl.h"
 
 namespace tateyama::configuration::resource {
 
@@ -47,7 +46,7 @@ class configuration_provider_impl : public tateyama::configuration::configuratio
     [[nodiscard]] std::string_view label() const noexcept override;
 
   private:
-    std::shared_ptr<status_info::resource::bridge> status_{};
+    std::unique_ptr<tateyama::api::server::database_info> database_info_{};
 };
 
 }

--- a/src/tateyama/configuration/resource/configuration_provider_impl.h
+++ b/src/tateyama/configuration/resource/configuration_provider_impl.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tateyama/status/resource/bridge.h"
+
+#include <tateyama/configuration/configuration_provider.h>
+
+namespace tateyama::configuration::resource {
+
+class configuration_provider_impl : public tateyama::configuration::configuration_provider {
+  public:
+    [[nodiscard]] api::server::database_info const& database_info() const noexcept override;
+
+    /**
+     * @brief setup the component (the state will be `ready`)
+     */
+    bool setup(framework::environment&) override;
+
+    /**
+     * @brief start the component (the state will be `activated`)
+     */
+    bool start(framework::environment&) override;
+
+    /**
+     * @brief shutdown the component (the state will be `deactivated`)
+     */
+    bool shutdown(framework::environment&) override;
+
+    [[nodiscard]] id_type id() const noexcept override;
+
+    /**
+     * @see `tateyama::framework::component::label()`
+     */
+    [[nodiscard]] std::string_view label() const noexcept override;
+
+  private:
+    std::shared_ptr<status_info::resource::bridge> status_{};
+};
+
+}

--- a/src/tateyama/configuration/resource/configuration_provider_impl.h
+++ b/src/tateyama/configuration/resource/configuration_provider_impl.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <tateyama/configuration/configuration_provider.h>
 #include "database_info_impl.h"

--- a/src/tateyama/configuration/resource/database_info_impl.h
+++ b/src/tateyama/configuration/resource/database_info_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2026 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@
 
 #include <tateyama/api/server/database_info.h>
 
-namespace tateyama::status_info::resource {
-
-class bridge;
+namespace tateyama::configuration::resource {
 
 /**
  * @brief database_info_impl

--- a/src/tateyama/datastore/resource/bridge.cpp
+++ b/src/tateyama/datastore/resource/bridge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 Project Tsurugi.
+ * Copyright 2018-2026 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include <tateyama/framework/component_ids.h>
 #include <tateyama/framework/resource.h>
 #include <tateyama/framework/transactional_kvs_resource.h>
+#include <tateyama/configuration/configuration_provider.h>
 
 namespace tateyama::datastore::resource {
 
@@ -52,6 +53,12 @@ static bool extract_config(environment& env, limestone::api::configuration& opti
         // XXX: direct porting from shirakami init code
         options = limestone::api::configuration({location}, location + "m");
         options.set_recover_max_parallelism(recover_param);
+        if (auto configuration = env.resource_repository().find<configuration::configuration_provider>(); configuration) {
+            options.set_instance_id(configuration->database_info().instance_id());
+        } else {
+            // happen only in tateyama/datastore/datastore_test.cpp
+            LOG(ERROR) << "cannot find configuration::configuration_provider, and thus instance_id has not been provided to datastore";
+        }
     } catch(std::exception const& e) {
         // error log should have been made
         return false;

--- a/src/tateyama/datastore/resource/bridge.cpp
+++ b/src/tateyama/datastore/resource/bridge.cpp
@@ -57,7 +57,7 @@ static bool extract_config(environment& env, limestone::api::configuration& opti
             options.set_instance_id(configuration->database_info().instance_id());
         } else {
             // happen only in tateyama/datastore/datastore_test.cpp
-            LOG(ERROR) << "cannot find configuration::configuration_provider, and thus instance_id has not been provided to datastore";
+            LOG(WARNING) << "cannot find configuration::configuration_provider, and thus instance_id has not been provided to datastore";
         }
     } catch(std::exception const& e) {
         // error log should have been made

--- a/src/tateyama/endpoint/common/request.h
+++ b/src/tateyama/endpoint/common/request.h
@@ -24,8 +24,8 @@
 #include <unistd.h>
 
 #include <tateyama/api/server/request.h>
+#include <tateyama/api/server/database_info.h>
 
-#include "tateyama/status/resource/database_info_impl.h"
 #include "session_info_impl.h"
 #include "tateyama/endpoint/common/endpoint_proto_utils.h"
 #include "worker_configuration.h"

--- a/src/tateyama/endpoint/ipc/bootstrap/ipc_listener.h
+++ b/src/tateyama/endpoint/ipc/bootstrap/ipc_listener.h
@@ -33,6 +33,7 @@
 #include <tateyama/logging.h>
 #include <tateyama/utils/boolalpha.h>
 #include <tateyama/framework/routing_service.h>
+#include <tateyama/configuration/configuration_provider.h>
 #include <tateyama/api/configuration.h>
 #include <tateyama/session/resource/bridge.h>
 
@@ -57,7 +58,7 @@ public:
           session_(env.resource_repository().find<session::resource::bridge>()),
           conf_(tateyama::endpoint::common::connection_type::ipc,
                 session_,
-                status_->database_info(),
+                env.resource_repository().find<configuration::configuration_provider>()->database_info(),
                 authentication_bridge(env),
                 administrators_),
           ipc_metrics_(env) {

--- a/src/tateyama/endpoint/loopback/loopback_request.h
+++ b/src/tateyama/endpoint/loopback/loopback_request.h
@@ -21,7 +21,7 @@
 
 #include <tateyama/api/server/request.h>
 
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "tateyama/endpoint/common/session_info_impl.h"
 
 namespace tateyama::endpoint::loopback {
@@ -99,7 +99,7 @@ private:
     const std::size_t service_id_;
     const std::string payload_;
 
-    const tateyama::status_info::resource::database_info_impl database_info_{};
+    const tateyama::configuration::resource::database_info_impl database_info_{};
     const tateyama::endpoint::common::administrators administrators_{"*"};
     const tateyama::endpoint::common::session_info_impl session_info_{session_id_, "loopback", "", administrators_};
     tateyama::api::server::session_store session_store_{};

--- a/src/tateyama/endpoint/stream/bootstrap/stream_listener.h
+++ b/src/tateyama/endpoint/stream/bootstrap/stream_listener.h
@@ -33,6 +33,7 @@
 #include <tateyama/logging.h>
 #include <tateyama/utils/boolalpha.h>
 #include <tateyama/framework/routing_service.h>
+#include <tateyama/configuration/configuration_provider.h>
 #include <tateyama/api/configuration.h>
 #include <tateyama/session/resource/bridge.h>
 #include "tateyama/authentication/resource/bridge.h"
@@ -67,7 +68,7 @@ public:
           session_(env.resource_repository().find<session::resource::bridge>()),
           conf_(tateyama::endpoint::common::connection_type::stream,
                 session_,
-                status_->database_info(),
+                env.resource_repository().find<configuration::configuration_provider>()->database_info(),
                 authentication_bridge(env),
                 administrators_),
           stream_metrics_(env) {

--- a/src/tateyama/framework/server.cpp
+++ b/src/tateyama/framework/server.cpp
@@ -190,9 +190,9 @@ server::server(framework::boot_mode mode, std::shared_ptr<api::configuration::wh
 
 void add_core_components(server& svr) {
     svr.add_resource(std::make_shared<diagnostic::resource::diagnostic_resource>());
+    svr.add_resource(std::make_shared<configuration::resource::configuration_provider_impl>());
     svr.add_resource(std::make_shared<metrics::resource::bridge>());
-    svr.add_resource(std::make_shared<status_info::resource::bridge>());
-    svr.add_resource(std::make_shared<configuration::resource::configuration_provider_impl>());  // place immediately after status_info::resource::bridge
+    svr.add_resource(std::make_shared<status_info::resource::bridge>());  // place after configuration::resource::configuration_provider_impl
     svr.add_resource(std::make_shared<datastore::resource::bridge>());
     svr.add_resource(std::make_shared<framework::transactional_kvs_resource>());
     svr.add_resource(std::make_shared<session::resource::bridge>());

--- a/src/tateyama/framework/server.cpp
+++ b/src/tateyama/framework/server.cpp
@@ -44,6 +44,7 @@
 #include <tateyama/metrics/service/bridge.h>
 #include <tateyama/metrics/resource/bridge.h>
 #include <tateyama/system/service/bridge.h>
+#include "tateyama/configuration/resource/configuration_provider_impl.h"
 #ifdef ENABLE_ALTIMETER
 #include "altimeter_logger.h"
 #include <tateyama/altimeter/service/bridge.h>
@@ -191,6 +192,7 @@ void add_core_components(server& svr) {
     svr.add_resource(std::make_shared<diagnostic::resource::diagnostic_resource>());
     svr.add_resource(std::make_shared<metrics::resource::bridge>());
     svr.add_resource(std::make_shared<status_info::resource::bridge>());
+    svr.add_resource(std::make_shared<configuration::resource::configuration_provider_impl>());  // place immediately after status_info::resource::bridge
     svr.add_resource(std::make_shared<datastore::resource::bridge>());
     svr.add_resource(std::make_shared<framework::transactional_kvs_resource>());
     svr.add_resource(std::make_shared<session::resource::bridge>());

--- a/src/tateyama/status/resource/bridge.cpp
+++ b/src/tateyama/status/resource/bridge.cpp
@@ -21,8 +21,8 @@
 #include <tateyama/logging.h>
 #include <glog/logging.h>
 
+#include <tateyama/api/server/database_info.h>
 #include <tateyama/status/resource/bridge.h>
-#include "database_info_impl.h"
 
 namespace tateyama::status_info::resource {
 
@@ -41,25 +41,7 @@ bool bridge::setup(environment& env) {
         set_digest(std::to_string(getpid()));  // for testing purpose
     }
 
-    // database name
     auto* ipc_section = conf->get_section("ipc_endpoint");
-    auto database_name_opt = ipc_section->get<std::string>("database_name");
-    if (!database_name_opt) {
-        LOG(ERROR) << "cannot find database_name at the ipc_endpoint section in the configuration";
-        return false;
-    }
-
-    // instance_id
-    auto* system_section = conf->get_section("system");
-    auto instance_id_opt = system_section->get<std::string>("instance_id");
-    if (!instance_id_opt) {
-        LOG(ERROR) << "cannot find  instance_id at the system section in the configuration";
-        return false;
-    }
-
-    // create database_info
-    database_info_ = std::make_unique<database_info_impl>(database_name_opt.value(), instance_id_opt.value());
-
     auto threads_opt = ipc_section->get<std::size_t>("threads");
     if (!threads_opt) {
         LOG(ERROR) << "cannot find thread at the ipc_endpoint section in the configuration";
@@ -76,10 +58,11 @@ bool bridge::setup(environment& env) {
     boost::interprocess::shared_memory_object::remove(status_file_name.c_str());
     shm_remover_ = std::make_unique<shm_remover>(status_file_name);
     try {
+        configuration_ = env.resource_repository().find<configuration::configuration_provider>();
         segment_ = std::make_unique<boost::interprocess::managed_shared_memory>(boost::interprocess::create_only, status_file_name.c_str(), shm_size(threads_opt.value() + admin_sessions_opt.value()));
         resource_status_memory_ = std::make_unique<resource_status_memory>(*segment_);
         resource_status_memory_->set_pid();
-        resource_status_memory_->set_database_name(database_name_opt.value());
+        resource_status_memory_->set_database_name(configuration_->database_info().name());
         return true;
     } catch(const boost::interprocess::interprocess_exception& ex) {
         std::stringstream ss{};

--- a/src/tateyama/status/resource/core.cpp
+++ b/src/tateyama/status/resource/core.cpp
@@ -21,8 +21,8 @@
 #include <tateyama/logging.h>
 #include <glog/logging.h>
 
+#include <tateyama/api/server/database_info.h>
 #include <tateyama/status/resource/bridge.h>
-#include "database_info_impl.h"
 
 namespace tateyama::status_info {   // FIXME should be tateyama::status::resource
 

--- a/src/tateyama/status/resource/database_info_impl.h
+++ b/src/tateyama/status/resource/database_info_impl.h
@@ -29,9 +29,9 @@ class bridge;
  */
 class database_info_impl : public tateyama::api::server::database_info {
 public:
-    explicit database_info_impl(std::string_view name) : name_(name) {}
+    explicit database_info_impl(std::string_view name, std::string_view instance_id) : name_(name), instance_id_(instance_id) {}
 
-    database_info_impl() : database_info_impl("name_has_not_been_given") {}
+    database_info_impl() : database_info_impl("name_has_not_been_given", "instance_id_has_not_been_given") {}
 
     [[nodiscard]] process_id_type process_id() const noexcept override { return process_id_; }
 
@@ -39,17 +39,16 @@ public:
 
     [[nodiscard]] time_type start_at() const noexcept override { return start_at_; }
 
+    [[nodiscard]] std::string_view instance_id() const noexcept override { return instance_id_; }
+
 private:
+    std::string name_;
+
+    std::string instance_id_;
+
     process_id_type process_id_{::getpid()};
 
-    std::string name_{};
-
     time_type start_at_{std::chrono::system_clock::now()};
-
-    // only tateyama::status_info::resource::bridge can use this.
-    void name(std::string_view name) { name_ = name; }
-
-    friend class tateyama::status_info::resource::bridge;
 };
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ file(GLOB SRCS
         "tateyama/request/service/*.cpp"
         "tateyama/authentication/resource/*.cpp"
         "tateyama/system/*.cpp"
+        "tateyama/configuration/*.cpp"
         )
 if (ENABLE_ALTIMETER)
     file(GLOB ALTIMETER_SOURCES

--- a/test/tateyama/configuration/configuration_provider_test.cpp
+++ b/test/tateyama/configuration/configuration_provider_test.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sstream>
+
+#include <tateyama/framework/server.h>
+#include <tateyama/configuration/configuration_provider.h>
+
+#include <gtest/gtest.h>
+#include <tateyama/test_utils/utility.h>
+
+namespace tateyama::configuration {
+
+using namespace std::literals::string_literals;
+using namespace std::string_view_literals;
+
+class configuration_provider_test : public ::testing::Test {
+public:
+    void SetUp() override {
+        std::stringstream ss{
+            "[ipc_endpoint]\n"
+            "  database_name=database_name_for_test\n"
+            "[system]\n"
+            "  instance_id=instance-id-for-test\n"
+        };
+        auto cfg = std::make_shared<tateyama::api::configuration::whole>(ss, tateyama::test_utils::default_configuration_for_tests);
+        server_ = std::make_unique<framework::server>(framework::boot_mode::database_server, cfg);
+        tateyama::test_utils::add_core_components_for_test(*server_);
+        server_->setup();
+        server_->start();
+    }
+    void TearDown() override {
+        server_->shutdown();
+    }
+protected:
+    std::unique_ptr<framework::server> server_{};
+};
+
+TEST_F(configuration_provider_test, basic) {
+    auto configuration_provider = server_->find_resource<configuration::configuration_provider>();
+    EXPECT_NE(nullptr, configuration_provider.get());
+
+    auto& dbinfo = configuration_provider->database_info();
+    EXPECT_EQ("database_name_for_test", dbinfo.name());
+    EXPECT_EQ("instance-id-for-test", dbinfo.instance_id());
+}
+
+}

--- a/test/tateyama/datastore/datastore_test.cpp
+++ b/test/tateyama/datastore/datastore_test.cpp
@@ -27,7 +27,7 @@
 #include <tateyama/proto/datastore/request.pb.h>
 #include <tateyama/proto/datastore/response.pb.h>
 
-#include "tateyama/status/resource/database_info_impl.h"
+#include <tateyama/api/server/database_info.h>
 #include "tateyama/endpoint/common/session_info_impl.h"
 
 #include <tateyama/test_utils/utility.h>

--- a/test/tateyama/endpoint/ipc/ipc_info_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_info_test.cpp
@@ -17,7 +17,7 @@
 #include "tateyama/endpoint/ipc/bootstrap/ipc_worker.h"
 #include "tateyama/endpoint/header_utils.h"
 #include <tateyama/proto/endpoint/request.pb.h>
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "ipc_client.h"
 
 #include <gtest/gtest.h>
@@ -85,7 +85,7 @@ class ipc_info_test : public ::testing::Test {
     int rv_;
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-info-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{database_name, "iid-ipc-info-test"};
     info_service service_{};
 
 protected:

--- a/test/tateyama/endpoint/ipc/ipc_info_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_info_test.cpp
@@ -85,7 +85,7 @@ class ipc_info_test : public ::testing::Test {
     int rv_;
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name};
+    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-info-test"};
     info_service service_{};
 
 protected:

--- a/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
@@ -17,7 +17,7 @@
 #include "tateyama/endpoint/ipc/bootstrap/ipc_worker.h"
 #include "tateyama/endpoint/header_utils.h"
 #include <tateyama/proto/endpoint/request.pb.h>
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "ipc_client.h"
 
 #include <gtest/gtest.h>
@@ -146,7 +146,7 @@ class ipc_lob_disallow_test : public ::testing::Test {
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-disallow-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-disallow-test"};
 
 protected:
     std::unique_ptr<bootstrap::server_wire_container_impl> wire_{};

--- a/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_disallow_test.cpp
@@ -146,7 +146,7 @@ class ipc_lob_disallow_test : public ::testing::Test {
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name};
+    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-disallow-test"};
 
 protected:
     std::unique_ptr<bootstrap::server_wire_container_impl> wire_{};

--- a/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
@@ -17,7 +17,7 @@
 #include "tateyama/endpoint/ipc/bootstrap/ipc_worker.h"
 #include "tateyama/endpoint/header_utils.h"
 #include <tateyama/proto/endpoint/request.pb.h>
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "ipc_client.h"
 
 #include <gtest/gtest.h>
@@ -146,7 +146,7 @@ class ipc_lob_test : public ::testing::Test {
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-test"};
 
 protected:
     std::unique_ptr<bootstrap::server_wire_container_impl> wire_{};

--- a/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_lob_test.cpp
@@ -146,7 +146,7 @@ class ipc_lob_test : public ::testing::Test {
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, database_info_, nullptr, administrators_};
 
 public:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name};
+    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-lob-test"};
 
 protected:
     std::unique_ptr<bootstrap::server_wire_container_impl> wire_{};

--- a/test/tateyama/endpoint/ipc/ipc_session_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_session_test.cpp
@@ -23,7 +23,7 @@
 #include "tateyama/endpoint/ipc/bootstrap/ipc_worker.h"
 #include "tateyama/endpoint/header_utils.h"
 #include <tateyama/proto/endpoint/request.pb.h>
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include <tateyama/session/resource/bridge.h>
 #include "ipc_client.h"
 
@@ -158,7 +158,7 @@ class ipc_session_test : public ::testing::Test {
     int rv_;
 
 protected:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-session-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{database_name, "iid-ipc-session-test"};
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     service_for_ipc_session_test service_{};
     std::unique_ptr<tateyama::endpoint::ipc::bootstrap::ipc_worker> worker_{};

--- a/test/tateyama/endpoint/ipc/ipc_session_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_session_test.cpp
@@ -158,7 +158,7 @@ class ipc_session_test : public ::testing::Test {
     int rv_;
 
 protected:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name};
+    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-session-test"};
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     service_for_ipc_session_test service_{};
     std::unique_ptr<tateyama::endpoint::ipc::bootstrap::ipc_worker> worker_{};

--- a/test/tateyama/endpoint/ipc/ipc_store_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_store_test.cpp
@@ -21,7 +21,7 @@
 #include "tateyama/endpoint/ipc/bootstrap/ipc_worker.h"
 #include "tateyama/endpoint/header_utils.h"
 #include <tateyama/proto/endpoint/request.pb.h>
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "ipc_client.h"
 
 #include <gtest/gtest.h>
@@ -104,7 +104,7 @@ class ipc_store_test : public ::testing::Test {
     int rv_;
 
 protected:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-store-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{database_name, "iid-ipc-store-test"};
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     store_service service_{};
     std::unique_ptr<tateyama::endpoint::ipc::bootstrap::ipc_worker> worker_{};

--- a/test/tateyama/endpoint/ipc/ipc_store_test.cpp
+++ b/test/tateyama/endpoint/ipc/ipc_store_test.cpp
@@ -104,7 +104,7 @@ class ipc_store_test : public ::testing::Test {
     int rv_;
 
 protected:
-    tateyama::status_info::resource::database_info_impl database_info_{database_name};
+    tateyama::status_info::resource::database_info_impl database_info_{database_name, "iid-ipc-store-test"};
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     store_service service_{};
     std::unique_ptr<tateyama::endpoint::ipc::bootstrap::ipc_worker> worker_{};

--- a/test/tateyama/endpoint/response_only_test.cpp
+++ b/test/tateyama/endpoint/response_only_test.cpp
@@ -21,6 +21,8 @@
 #include "tateyama/endpoint/ipc/ipc_request.h"
 #include "tateyama/endpoint/ipc/ipc_response.h"
 
+#include "tateyama/configuration/resource/database_info_impl.h"
+
 #include <tateyama/endpoint/ipc/bootstrap/server_wires_impl.h>
 #include "header_utils.h"
 
@@ -50,7 +52,7 @@ public:
 
     std::shared_ptr<bootstrap::server_wire_container_impl> wire_;
 
-    tateyama::status_info::resource::database_info_impl dmy_dbinfo_{};
+    tateyama::configuration::resource::database_info_impl dmy_dbinfo_{};
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, dmy_dbinfo_, nullptr, administrators_};
     tateyama::endpoint::common::resources resources_{conf_, session_id, "", administrators_};
 

--- a/test/tateyama/endpoint/result_set_limit_test.cpp
+++ b/test/tateyama/endpoint/result_set_limit_test.cpp
@@ -26,6 +26,8 @@
 #include "tateyama/endpoint/ipc/ipc_request.h"
 #include "tateyama/endpoint/ipc/ipc_response.h"
 
+#include "tateyama/configuration/resource/database_info_impl.h"
+
 #include <tateyama/endpoint/ipc/bootstrap/server_wires_impl.h>
 #include "header_utils.h"
 
@@ -62,7 +64,7 @@ public:
 
     std::shared_ptr<bootstrap::server_wire_container_impl> wire_;
 
-    tateyama::status_info::resource::database_info_impl dmy_dbinfo_{};
+    tateyama::configuration::resource::database_info_impl dmy_dbinfo_{};
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, dmy_dbinfo_, nullptr, administrators_};
     tateyama::endpoint::common::resources resources_{conf_, session_id, "", administrators_};
 

--- a/test/tateyama/endpoint/result_set_test.cpp
+++ b/test/tateyama/endpoint/result_set_test.cpp
@@ -22,6 +22,8 @@
 #include "tateyama/endpoint/ipc/ipc_request.h"
 #include "tateyama/endpoint/ipc/ipc_response.h"
 
+#include "tateyama/configuration/resource/database_info_impl.h"
+
 #include <tateyama/endpoint/ipc/bootstrap/server_wires_impl.h>
 #include "header_utils.h"
 
@@ -56,7 +58,7 @@ public:
 
     std::shared_ptr<bootstrap::server_wire_container_impl> wire_;
 
-    tateyama::status_info::resource::database_info_impl dmy_dbinfo_{};
+    tateyama::configuration::resource::database_info_impl dmy_dbinfo_{};
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, dmy_dbinfo_, nullptr, administrators_};
     tateyama::endpoint::common::resources resources_{conf_, session_id, "", administrators_};
 

--- a/test/tateyama/endpoint/stream/stream_decline_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_decline_test.cpp
@@ -18,7 +18,7 @@
 
 #include "tateyama/endpoint/stream/bootstrap/stream_worker.h"
 #include "tateyama/endpoint/header_utils.h"
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "stream_client.h"
 
 #include <gtest/gtest.h>
@@ -85,7 +85,7 @@ private:
     info_service_for_test& service_;
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_decline_test", "iid-stream-decline-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{"stream_decline_test", "iid-stream-decline-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 }

--- a/test/tateyama/endpoint/stream/stream_decline_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_decline_test.cpp
@@ -85,7 +85,7 @@ private:
     info_service_for_test& service_;
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_info_test"};
+    tateyama::status_info::resource::database_info_impl database_info_{"stream_decline_test", "iid-stream-decline-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 }

--- a/test/tateyama/endpoint/stream/stream_info_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_info_test.cpp
@@ -102,7 +102,7 @@ class stream_info_test : public ::testing::Test {
 
 public:
     tateyama::endpoint::stream::info_service_for_test service_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_info_test"};
+    tateyama::status_info::resource::database_info_impl database_info_{"stream_info_test", "iid-stream-info-test"};
     tateyama::endpoint::stream::stream_listener_for_info_test listener_{service_, database_info_};
     std::thread thread_{};
 };

--- a/test/tateyama/endpoint/stream/stream_info_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_info_test.cpp
@@ -18,7 +18,7 @@
 
 #include "tateyama/endpoint/stream/bootstrap/stream_worker.h"
 #include "tateyama/endpoint/header_utils.h"
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "stream_client.h"
 
 #include <gtest/gtest.h>
@@ -57,7 +57,7 @@ private:
 
 class stream_listener_for_info_test {
 public:
-    stream_listener_for_info_test(info_service_for_test& service, tateyama::status_info::resource::database_info_impl& database_info) : service_(service), conf_(tateyama::endpoint::common::connection_type::stream, nullptr, database_info, nullptr, administrators_) {
+    stream_listener_for_info_test(info_service_for_test& service, tateyama::configuration::resource::database_info_impl& database_info) : service_(service), conf_(tateyama::endpoint::common::connection_type::stream, nullptr, database_info, nullptr, administrators_) {
     }
     void operator()() {
         while (true) {
@@ -102,7 +102,7 @@ class stream_info_test : public ::testing::Test {
 
 public:
     tateyama::endpoint::stream::info_service_for_test service_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_info_test", "iid-stream-info-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{"stream_info_test", "iid-stream-info-test"};
     tateyama::endpoint::stream::stream_listener_for_info_test listener_{service_, database_info_};
     std::thread thread_{};
 };

--- a/test/tateyama/endpoint/stream/stream_session_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_session_test.cpp
@@ -20,7 +20,7 @@
 
 #include "tateyama/endpoint/stream/bootstrap/stream_worker.h"
 #include "tateyama/endpoint/header_utils.h"
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "stream_client.h"
 
 #include <gtest/gtest.h>
@@ -136,7 +136,7 @@ private:
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_session_test", "iid-stream-session-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{"stream_session_test", "iid-stream-session-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 

--- a/test/tateyama/endpoint/stream/stream_session_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_session_test.cpp
@@ -136,7 +136,7 @@ private:
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_info_test"};
+    tateyama::status_info::resource::database_info_impl database_info_{"stream_session_test", "iid-stream-session-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 

--- a/test/tateyama/endpoint/stream/stream_store_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_store_test.cpp
@@ -93,7 +93,7 @@ private:
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_store_test"};
+    tateyama::status_info::resource::database_info_impl database_info_{"stream_store_test", "iid-stream-store-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 }

--- a/test/tateyama/endpoint/stream/stream_store_test.cpp
+++ b/test/tateyama/endpoint/stream/stream_store_test.cpp
@@ -21,7 +21,7 @@
 
 #include "tateyama/endpoint/stream/bootstrap/stream_worker.h"
 #include "tateyama/endpoint/header_utils.h"
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "stream_client.h"
 
 #include <gtest/gtest.h>
@@ -93,7 +93,7 @@ private:
     std::unique_ptr<tateyama::endpoint::common::configuration> conf_{};
     connection_socket connection_socket_{tateyama::api::endpoint::stream::stream_client::PORT_FOR_TEST};
     std::unique_ptr<tateyama::endpoint::stream::bootstrap::stream_worker> worker_{};
-    tateyama::status_info::resource::database_info_impl database_info_{"stream_store_test", "iid-stream-store-test"};
+    tateyama::configuration::resource::database_info_impl database_info_{"stream_store_test", "iid-stream-store-test"};
     tateyama::endpoint::common::administrators administrators_{"*"};
 };
 }

--- a/test/tateyama/endpoint/writer_limit_test.cpp
+++ b/test/tateyama/endpoint/writer_limit_test.cpp
@@ -26,6 +26,8 @@
 #include "tateyama/endpoint/ipc/ipc_request.h"
 #include "tateyama/endpoint/ipc/ipc_response.h"
 
+#include "tateyama/configuration/resource/database_info_impl.h"
+
 #include <tateyama/endpoint/ipc/bootstrap/server_wires_impl.h>
 #include "header_utils.h"
 
@@ -62,7 +64,7 @@ public:
 
     std::shared_ptr<bootstrap::server_wire_container_impl> wire_;
 
-    tateyama::status_info::resource::database_info_impl dmy_dbinfo_{};
+    tateyama::configuration::resource::database_info_impl dmy_dbinfo_{};
     tateyama::endpoint::common::configuration conf_{tateyama::endpoint::common::connection_type::ipc, nullptr, dmy_dbinfo_, nullptr, administrators_};
     tateyama::endpoint::common::resources resources_{conf_, session_id, "", administrators_};
 

--- a/test/tateyama/framework/router_test.cpp
+++ b/test/tateyama/framework/router_test.cpp
@@ -26,7 +26,7 @@
 #include <tateyama/proto/core/request.pb.h>
 #include <tateyama/proto/core/response.pb.h>
 
-#include "tateyama/status/resource/database_info_impl.h"
+#include <tateyama/api/server/database_info.h>
 #include "tateyama/endpoint/common/session_info_impl.h"
 
 #include <gtest/gtest.h>

--- a/test/tateyama/test_utils/request_response.h
+++ b/test/tateyama/test_utils/request_response.h
@@ -21,7 +21,7 @@
 #include <tateyama/api/server/request.h>
 #include <tateyama/api/server/response.h>
 
-#include "tateyama/status/resource/database_info_impl.h"
+#include "tateyama/configuration/resource/database_info_impl.h"
 #include "tateyama/endpoint/common/session_info_impl.h"
 
 namespace tateyama::test_utils {
@@ -90,7 +90,7 @@ public:
     std::size_t local_id_{};
     std::string payload_{};
 
-    tateyama::status_info::resource::database_info_impl database_info_{};
+    tateyama::configuration::resource::database_info_impl database_info_{};
     tateyama::endpoint::common::administrators administrators_{"*"};
     tateyama::endpoint::common::session_info_impl session_info_{0, "", "", administrators_};
     tateyama::api::server::session_store session_store_{};

--- a/test/tateyama/test_utils/test_server.h
+++ b/test/tateyama/test_utils/test_server.h
@@ -24,6 +24,7 @@
 #include <tateyama/metrics/service/bridge.h>
 #include <tateyama/metrics/resource/bridge.h>
 #include <tateyama/system/service/bridge.h>
+#include "tateyama/configuration/resource/configuration_provider_impl.h"
 #ifdef ENABLE_ALTIMETER
 #include <tateyama/altimeter/service/bridge.h>
 #endif
@@ -39,6 +40,7 @@
 namespace tateyama::test_utils {
 
     static void add_core_components_for_test(tateyama::framework::server& svr) {
+        svr.add_resource(std::make_shared<configuration::resource::configuration_provider_impl>());
         svr.add_resource(std::make_shared<tateyama::metrics::resource::bridge>());
         svr.add_resource(std::make_shared<tateyama::status_info::resource::bridge>());
         svr.add_resource(std::make_shared<tateyama::session::resource::bridge>());
@@ -58,6 +60,7 @@ namespace tateyama::test_utils {
     }
 
     static void add_core_components_for_datastore_test(tateyama::framework::server& svr) {
+        svr.add_resource(std::make_shared<configuration::resource::configuration_provider_impl>());
         svr.add_resource(std::make_shared<tateyama::metrics::resource::bridge>());
         svr.add_resource(std::make_shared<tateyama::status_info::resource::bridge>());
         svr.add_resource(std::make_shared<datastore::resource::bridge>());

--- a/test/tateyama/test_utils/utility.h
+++ b/test/tateyama/test_utils/utility.h
@@ -115,7 +115,7 @@ static constexpr std::string_view default_configuration_for_tests {  // NOLINT
         "max_concurrent_transactions=\n"
 
     "[system]\n"
-        "pid_directory = /tmp\n"
+        "pid_directory=/tmp\n"
         "instance_id=instance-id-for-test\n"
 
     "[authentication]\n"

--- a/test/tateyama/test_utils/utility.h
+++ b/test/tateyama/test_utils/utility.h
@@ -116,6 +116,7 @@ static constexpr std::string_view default_configuration_for_tests {  // NOLINT
 
     "[system]\n"
         "pid_directory = /tmp\n"
+        "instance_id=instance-id-for-test\n"
 
     "[authentication]\n"
         "enabled=false\n"


### PR DESCRIPTION
Implements instance_id tracking for database processes by introducing a new configuration_provider resource that centralizes database metadata access.

## Changes

- **New resource**: `configuration_provider` exposes `database_info` interface with instance_id support
  - Reads `system.instance_id` from configuration during setup
  - Resource ID: `tateyama::framework::resource_id_configuration`

- **Refactored database_info_impl**: Moved from `status::resource` to `configuration::resource`
  - Extended API with `instance_id()` method
  - Now constructed with both database name and instance_id

- **Updated dependencies**: Status and datastore resources now retrieve database_info from configuration_provider instead of managing their own instances

- **Configuration requirements**: 
  - `ipc_endpoint.database_name` (existing)
  - `system.instance_id` (new, required)

## Usage

```cpp
// Access via configuration provider resource
auto* config_provider = env.resource_repository().find<configuration::configuration_provider>();
auto& db_info = config_provider->database_info();
auto instance_id = db_info.instance_id();
```

https://github.com/project-tsurugi/tsurugi-issues/issues/1409