### PR TITLE
ci: fix the current path in install-dependencies when included as a submodule

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -8,6 +8,9 @@ inputs:
   path:
     description: Relative path under $GITHUB_WORKSPACE to place the repository
     default: build-deps
+  working-directory:
+    description: Relative path under $GITHUB_WORKSPACE to run the command
+    default: .
   sharksfin_implementation:
     description: switch sharksfin implementation
     default: shirakami
@@ -133,6 +136,7 @@ runs:
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Install_Data_Relay_gRPC
       run: |


### PR DESCRIPTION
This pull request updates the custom GitHub Action install-dependencies to add support for specifying a working directory for command execution. This fixes problems to use this actions via submodule includes another repositories.