### PR TITLE
avoid memory allocator bug in newer boost

### DIFF
--- a/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
+++ b/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
@@ -38,7 +38,11 @@ class server_wire_container_impl : public server_wire_container
     static constexpr std::size_t request_buffer_size = (1<<12);   //  4K bytes NOLINT
     static constexpr std::size_t response_buffer_size = (1<<13);  //  8K bytes NOLINT
     static constexpr std::size_t data_channel_overhead = 7700;   //  by experiment NOLINT
+#if BOOST_VERSION < 108600        
     static constexpr std::size_t total_overhead = (1<<14);   //  16K bytes by experiment NOLINT
+#else
+    static constexpr std::size_t total_overhead = ((1<<14) + (1<<16));   //  16K + 64K bytes to avoid new boost bug NOLINT
+#endif
 
 public:
     class resultset_wires_container_impl;

--- a/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
+++ b/src/tateyama/endpoint/ipc/bootstrap/server_wires_impl.h
@@ -25,6 +25,8 @@
 #include <string_view>
 #include <functional>
 
+#include <boost/version.hpp>
+
 #include <glog/logging.h>
 #include <tateyama/logging.h>
 
@@ -38,7 +40,7 @@ class server_wire_container_impl : public server_wire_container
     static constexpr std::size_t request_buffer_size = (1<<12);   //  4K bytes NOLINT
     static constexpr std::size_t response_buffer_size = (1<<13);  //  8K bytes NOLINT
     static constexpr std::size_t data_channel_overhead = 7700;   //  by experiment NOLINT
-#if BOOST_VERSION < 108600        
+#if BOOST_VERSION < 108600
     static constexpr std::size_t total_overhead = (1<<14);   //  16K bytes by experiment NOLINT
 #else
     static constexpr std::size_t total_overhead = ((1<<14) + (1<<16));   //  16K + 64K bytes to avoid new boost bug NOLINT


### PR DESCRIPTION
This PR adjusts IPC shared-memory sizing to work around a Boost 1.86+ allocator issue by increasing the per-session overhead used by `server_wire_container_impl`.

**Changes:**
- Adds a `BOOST_VERSION` conditional around `total_overhead`.
- Keeps the existing 16 KiB overhead for Boost versions before 1.86.0.
- Adds 64 KiB extra overhead for Boost 1.86.0 and newer.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1437